### PR TITLE
[Feat/3] implement OAuth2 Login 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,14 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    //jsonwebtoken
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+
+    //webclient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -1,46 +1,47 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
-	compileOnly 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
 
-	//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	//	testImplementation 'org.springframework.security:spring-security-test'
+    annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/adaptor/MemberAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/adaptor/MemberAdaptor.java
@@ -1,0 +1,23 @@
+package com.ploggingbuddy.domain.member.adaptor;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import com.ploggingbuddy.global.annotation.adaptor.Adaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Adaptor
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberAdaptor {
+
+    private final MemberRepository memberRepository;
+
+    public Member queryByUsername(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("username을 찾을 수 없음: " + username));
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/member/adaptor/MemberAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/adaptor/MemberAdaptor.java
@@ -20,4 +20,9 @@ public class MemberAdaptor {
                 .orElseThrow(() -> new IllegalArgumentException("username을 찾을 수 없음: " + username));
     }
 
+    public Member queryById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("id를 찾을 수 없음: " + id));
+    }
+
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -7,6 +7,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 @Entity
@@ -19,7 +25,7 @@ import lombok.experimental.SuperBuilder;
                 @Index(name = "idx_member_username", columnList = "username"),
         }
 )
-public class Member extends BaseTimeEntity {
+public class Member extends BaseTimeEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,4 +42,13 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(this.role.getName()));
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -1,0 +1,39 @@
+package com.ploggingbuddy.domain.member.entity;
+
+import com.ploggingbuddy.domain.auditing.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "member",
+        indexes = {
+                @Index(name = "idx_member_username", columnList = "username"),
+        }
+)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String nickname;
+
+    private String email;
+
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Role.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Role.java
@@ -1,0 +1,11 @@
+package com.ploggingbuddy.domain.member.entity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST"), USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+
+    private final String name;
+}

--- a/src/main/java/com/ploggingbuddy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.ploggingbuddy.domain.member.repository;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByUsername(String username);
+
+}

--- a/src/main/java/com/ploggingbuddy/global/annotation/adaptor/Adaptor.java
+++ b/src/main/java/com/ploggingbuddy/global/annotation/adaptor/Adaptor.java
@@ -1,0 +1,15 @@
+package com.ploggingbuddy.global.annotation.adaptor;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface Adaptor {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/controller/KakaoController.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/controller/KakaoController.java
@@ -1,0 +1,27 @@
+package com.ploggingbuddy.global.auth.controller;
+
+import com.ploggingbuddy.global.auth.service.KakaoClientService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kakao/test")
+public class KakaoController {
+
+    private final KakaoClientService kakaoClientService;
+
+    //test
+    @GetMapping("/unlink/{id}")
+    public ResponseEntity<?> unlink(@PathVariable("id") Long memberId) {
+        kakaoClientService.unlinkKakaoAccount(memberId);
+        return ResponseEntity.ok("Kakao account unlinked successfully.");
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/domain/CustomOAuthUser.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/domain/CustomOAuthUser.java
@@ -1,5 +1,6 @@
 package com.ploggingbuddy.global.auth.domain;
 
+import com.ploggingbuddy.domain.member.entity.Member;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/ploggingbuddy/global/auth/domain/CustomOAuthUser.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/domain/CustomOAuthUser.java
@@ -1,0 +1,83 @@
+package com.ploggingbuddy.global.auth.domain;
+
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class CustomOAuthUser implements OAuth2User, UserDetails {
+
+    private Member member;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public CustomOAuthUser(Member member, Collection<? extends GrantedAuthority> authorities) {
+        this.member = member;
+        this.authorities = authorities;
+    }
+
+    public CustomOAuthUser(Member member, Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes) {
+        this.member = member;
+        this.authorities = authorities;
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getMemberInfo(){
+        Map<String, Object> info = new HashMap<>();
+        info.put("username", member.getUsername());
+        info.put("email", member.getEmail());
+        info.put("role", member.getRole());
+        return info;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/domain/OAuth2Attributes.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/domain/OAuth2Attributes.java
@@ -1,0 +1,29 @@
+package com.ploggingbuddy.global.auth.domain;
+
+import com.ploggingbuddy.global.auth.dto.KakaoUserInfo;
+import com.ploggingbuddy.global.auth.dto.OAuth2UserInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuth2Attributes {
+    private String nameAttributeKey;
+    private OAuth2UserInfo oAuth2UserInfo;
+
+    @Builder
+    public OAuth2Attributes(String nameAttributeKey, OAuth2UserInfo oAuth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oAuth2UserInfo = oAuth2UserInfo;
+    }
+
+    // OAuth2Utils 를 통해 분기처리 없이 생성된 OAuth2UserInfo 를 반환
+    public static OAuth2Attributes of(String userNameAttributeName,
+                                      Map<String, Object> attributes) {
+        return OAuth2Attributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oAuth2UserInfo(new KakaoUserInfo(attributes))
+                .build();
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/domain/OAuth2Attributes.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/domain/OAuth2Attributes.java
@@ -18,7 +18,6 @@ public class OAuth2Attributes {
         this.oAuth2UserInfo = oAuth2UserInfo;
     }
 
-    // OAuth2Utils 를 통해 분기처리 없이 생성된 OAuth2UserInfo 를 반환
     public static OAuth2Attributes of(String userNameAttributeName,
                                       Map<String, Object> attributes) {
         return OAuth2Attributes.builder()

--- a/src/main/java/com/ploggingbuddy/global/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/dto/KakaoUserInfo.java
@@ -25,4 +25,10 @@ public class KakaoUserInfo extends OAuth2UserInfo {
         Map<String, Object> profile = (Map<String, Object>) account.get("profile");
         return (String) profile.get("profile_image_url");
     }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return (String) profile.get("nickname");
+    }
 }

--- a/src/main/java/com/ploggingbuddy/global/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,27 @@
+package com.ploggingbuddy.global.auth.dto;
+
+import java.util.Map;
+
+public class KakaoUserInfo extends OAuth2UserInfo {
+    private final Map<String, Object> account;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        super(attributes);
+        this.account = (Map<String, Object>) attributes.get("kakao_account");
+    }
+
+    @Override
+    public String getSocialId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return account.get("email").toString();
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return account.get("profile_image").toString();
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/dto/KakaoUserInfo.java
@@ -22,6 +22,7 @@ public class KakaoUserInfo extends OAuth2UserInfo {
 
     @Override
     public String getProfileImageUrl() {
-        return account.get("profile_image").toString();
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return (String) profile.get("profile_image_url");
     }
 }

--- a/src/main/java/com/ploggingbuddy/global/auth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/dto/OAuth2UserInfo.java
@@ -20,4 +20,7 @@ public abstract class OAuth2UserInfo {
     //프로필 사진
     public abstract String getProfileImageUrl();
 
+    //닉네임
+    public abstract String getNickname();
+
 }

--- a/src/main/java/com/ploggingbuddy/global/auth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/dto/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.ploggingbuddy.global.auth.dto;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    //제공자에서 발급해주는 아이디
+    public abstract String getSocialId();
+
+    //이메일
+    public abstract String getEmail();
+
+    //프로필 사진
+    public abstract String getProfileImageUrl();
+
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/handler/CustomOAuth2LoginFailureHandler.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/handler/CustomOAuth2LoginFailureHandler.java
@@ -1,0 +1,22 @@
+package com.ploggingbuddy.global.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomOAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException{
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인에 실패하였습니다.");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/handler/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/handler/CustomOAuth2LoginSuccessHandler.java
@@ -1,0 +1,56 @@
+package com.ploggingbuddy.global.auth.handler;
+
+import com.ploggingbuddy.security.dto.JwtToken;
+import com.ploggingbuddy.security.service.TokenService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final String REDIRECT_URI = "http://localhost:8080/"; // todo redirect uri 작성
+    private final TokenService tokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        if (response.isCommitted()) {
+            return;
+        }
+        log.info("--------------------------- OAuth2LoginSuccessHandler ---------------------------");
+        JwtToken jwtToken = tokenService.generateToken(authentication);
+        String provider = null;
+
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken) authentication;
+            provider = oauth2Token.getAuthorizedClientRegistrationId();
+            Collection<GrantedAuthority> authorities = oauth2Token.getAuthorities();
+            authorities.forEach(grantedAuthority -> log.info("role {}", grantedAuthority.getAuthority()));
+        }
+
+        String url = UriComponentsBuilder.fromHttpUrl(REDIRECT_URI)
+//                .queryParam("code", jwtToken.getAccessToken())
+                .queryParam("provider", provider)
+                .build()
+                .toUriString();
+
+        response.addHeader("Authorization",
+                jwtToken.getGrantType() + " " + jwtToken.getAccessToken());
+
+        response.sendRedirect(url);
+
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/handler/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/handler/CustomOAuth2LoginSuccessHandler.java
@@ -42,7 +42,7 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
         }
 
         String url = UriComponentsBuilder.fromHttpUrl(REDIRECT_URI)
-//                .queryParam("code", jwtToken.getAccessToken())
+                .queryParam("code", jwtToken.getAccessToken())
                 .queryParam("provider", provider)
                 .build()
                 .toUriString();

--- a/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,77 @@
+package com.ploggingbuddy.global.auth.service;
+
+import com.ploggingbuddy.global.auth.domain.CustomOAuthUser;
+import com.ploggingbuddy.global.auth.domain.OAuth2Attributes;
+import com.ploggingbuddy.global.auth.dto.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final String TEMP_NICKNAME_HEADER = "PLG_";
+    private final int TEMP_NICKNAME_LENGTH = 10;
+
+    private final MemberAdaptor memberAdaptor;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        log.info("registrationId={}", registrationId);
+        log.info("userNameAttributeName={}", userNameAttributeName);
+
+        // 소셜에서 전달받은 정보를 가진 OAuth2User 에서 Map 을 추출하여 OAuth2Attribute 를 생성
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 내부에서 OAuth2UserInfo 생성과 함께 OAuth2Attributes 를 생성해서 반환
+        OAuth2Attributes oauth2Attributes = OAuth2Attributes.of(userNameAttributeName, attributes);
+        OAuth2UserInfo oauth2UserInfo = oauth2Attributes.getOAuth2UserInfo();
+
+        // 값 추출
+        String socialId = oauth2UserInfo.getSocialId();
+        String email = oauth2UserInfo.getEmail();
+        String profileImageUrl = oauth2UserInfo.getProfileImageUrl();
+
+        log.info("socialId={}", socialId);
+        log.info("email={}", email);
+
+        String username = registrationId + "_" + socialId;
+        Optional<Member> targetMember = memberAdaptor.queryByUsername(username)
+        Member member = targetMember.orElseGet(() -> signupSocialMember(username, email, profileImageUrl));
+
+        return new CustomOAuthUser(member,
+                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())),
+                attributes);
+    }
+
+    private Member signupSocialMember(String username, String email, String profileImageUrl) {
+        //todo generate UUID random nickname
+//        String nickname = TEMP_NICKNAME_HEADER +
+        Member member = Member.builder()
+                .username(username)
+                .nickname(nickname)
+                .email(email)
+                .profileImageUrl(profileImageUrl)
+                .role(Role.USER)
+                .build();
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
@@ -28,9 +28,6 @@ import java.util.UUID;
 @Transactional
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final String TEMP_NICKNAME_HEADER = "PLG_";
-    private final int TEMP_NICKNAME_LENGTH = 10;
-
     private final MemberRepository memberRepository;
 
     @Override
@@ -54,6 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String socialId = oauth2UserInfo.getSocialId();
         String email = oauth2UserInfo.getEmail();
         String profileImageUrl = oauth2UserInfo.getProfileImageUrl();
+        String nickname = oauth2UserInfo.getNickname();
 
         log.info("socialId={}", socialId);
         log.info("email={}", email);
@@ -62,15 +60,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 카카오 전용
         String username = socialId;
         Optional<Member> targetMember = memberRepository.findByUsername(username);
-        Member member = targetMember.orElseGet(() -> signupSocialMember(username, email, profileImageUrl));
+        Member member = targetMember.orElseGet(() -> signupSocialMember(username, email, nickname, profileImageUrl));
 
         return new CustomOAuthUser(member,
                 Collections.singleton(new SimpleGrantedAuthority(member.getRole().getName())),
                 attributes);
     }
 
-    private Member signupSocialMember(String username, String email, String profileImageUrl) {
-        String nickname = TEMP_NICKNAME_HEADER + UUID.randomUUID().toString().substring(0, TEMP_NICKNAME_LENGTH);
+    private Member signupSocialMember(String username, String email, String nickname, String profileImageUrl) {
         Member member = Member.builder()
                 .username(username)
                 .nickname(nickname)

--- a/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
@@ -1,5 +1,9 @@
 package com.ploggingbuddy.global.auth.service;
 
+import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.entity.Role;
+import com.ploggingbuddy.domain.member.repository.MemberRepository;
 import com.ploggingbuddy.global.auth.domain.CustomOAuthUser;
 import com.ploggingbuddy.global.auth.domain.OAuth2Attributes;
 import com.ploggingbuddy.global.auth.dto.OAuth2UserInfo;
@@ -26,7 +30,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final String TEMP_NICKNAME_HEADER = "PLG_";
     private final int TEMP_NICKNAME_LENGTH = 10;
 
-    private final MemberAdaptor memberAdaptor;
+    private final MemberRepository memberRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -54,17 +58,17 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         log.info("email={}", email);
 
         String username = registrationId + "_" + socialId;
-        Optional<Member> targetMember = memberAdaptor.queryByUsername(username)
+        Optional<Member> targetMember = memberRepository.findByUsername(username);
         Member member = targetMember.orElseGet(() -> signupSocialMember(username, email, profileImageUrl));
 
         return new CustomOAuthUser(member,
-                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())),
+                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getName())),
                 attributes);
     }
 
     private Member signupSocialMember(String username, String email, String profileImageUrl) {
         //todo generate UUID random nickname
-//        String nickname = TEMP_NICKNAME_HEADER +
+        String nickname = TEMP_NICKNAME_HEADER;
         Member member = Member.builder()
                 .username(username)
                 .nickname(nickname)

--- a/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
@@ -57,8 +57,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         log.info("socialId={}", socialId);
         log.info("email={}", email);
+        log.info("profileImageUrl={}", profileImageUrl);
 
-        String username = registrationId + "_" + socialId;
+        // 카카오 전용
+        String username = socialId;
         Optional<Member> targetMember = memberRepository.findByUsername(username);
         Member member = targetMember.orElseGet(() -> signupSocialMember(username, email, profileImageUrl));
 

--- a/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/service/CustomOAuth2UserService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -67,8 +68,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private Member signupSocialMember(String username, String email, String profileImageUrl) {
-        //todo generate UUID random nickname
-        String nickname = TEMP_NICKNAME_HEADER;
+        String nickname = TEMP_NICKNAME_HEADER + UUID.randomUUID().toString().substring(0, TEMP_NICKNAME_LENGTH);
         Member member = Member.builder()
                 .username(username)
                 .nickname(nickname)

--- a/src/main/java/com/ploggingbuddy/global/auth/service/KakaoClientService.java
+++ b/src/main/java/com/ploggingbuddy/global/auth/service/KakaoClientService.java
@@ -1,0 +1,58 @@
+package com.ploggingbuddy.global.auth.service;
+
+import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoClientService {
+
+    private final MemberAdaptor memberAdaptor;
+    private final MemberRepository memberRepository;
+    private final RestTemplate restTemplate;
+
+    private final String UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String adminKey;
+
+    @Transactional
+    public void unlinkKakaoAccount(Long memberId) {
+        Member member = memberAdaptor.queryById(memberId);
+        unlinkFromKakao(member.getUsername());
+        memberRepository.delete(member); //회원 탈퇴
+    }
+
+    private void unlinkFromKakao(String kakaoId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + adminKey);
+
+        // 요청 본문에 target_id_type=user_id와 target_id=회원번호 값 전달
+        String requestBody = "target_id_type=user_id&target_id=" + kakaoId;
+
+        HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
+
+        try {
+            restTemplate.postForObject(UNLINK_URL, request, String.class);
+            log.info("카카오 연동 해제 API 호출 성공: {}", kakaoId);
+        } catch (Exception e) {
+            log.error("카카오 연동 해제 API 호출 실패: {}", e.getMessage());
+            throw new RuntimeException("카카오 연동 해제에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/config/restTemplate/RestTemplateConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/restTemplate/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.ploggingbuddy.global.config.restTemplate;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/config/webMvc/WebMvcConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/webMvc/WebMvcConfig.java
@@ -1,0 +1,28 @@
+package com.ploggingbuddy.global.config.webMvc;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+    //todo 환경변수 파일로
+    private static final String CORS_FRONT_PATH = "http://localhost:3000";
+
+    //CORS setting
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .allowedOriginPatterns(CORS_FRONT_PATH)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+
+    }
+}

--- a/src/main/java/com/ploggingbuddy/security/aop/CurrentMember.java
+++ b/src/main/java/com/ploggingbuddy/security/aop/CurrentMember.java
@@ -1,0 +1,11 @@
+package com.ploggingbuddy.security.aop;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentMember {
+}

--- a/src/main/java/com/ploggingbuddy/security/config/SecurityConfig.java
+++ b/src/main/java/com/ploggingbuddy/security/config/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig {
     private final CustomOAuth2LoginSuccessHandler customOAuth2LoginSuccessHandler;
     private final CustomOAuth2LoginFailureHandler customOAuth2LoginFailureHandler;
 
-    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+//    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
@@ -52,6 +52,8 @@ public class SecurityConfig {
 //    private void configureExceptionHandling(HttpSecurity httpSecurity) throws Exception {
 //        httpSecurity
 //                .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
+//    .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+//                        .accessDeniedHandler(jwtAccessDeniedHandler));
 //    }
 
 

--- a/src/main/java/com/ploggingbuddy/security/config/SecurityConfig.java
+++ b/src/main/java/com/ploggingbuddy/security/config/SecurityConfig.java
@@ -1,0 +1,139 @@
+package com.ploggingbuddy.security.config;
+
+import com.ploggingbuddy.global.auth.handler.CustomOAuth2LoginFailureHandler;
+import com.ploggingbuddy.global.auth.handler.CustomOAuth2LoginSuccessHandler;
+import com.ploggingbuddy.global.auth.service.CustomOAuth2UserService;
+import com.ploggingbuddy.security.filter.JwtAuthenticationFilter;
+import com.ploggingbuddy.security.filter.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.util.List;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2LoginSuccessHandler customOAuth2LoginSuccessHandler;
+    private final CustomOAuth2LoginFailureHandler customOAuth2LoginFailureHandler;
+
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        configureCorsAndSecurity(httpSecurity);
+        configureAuth(httpSecurity);
+        configureOAuth2(httpSecurity);
+//        configureExceptionHandling(httpSecurity);
+        addFilter(httpSecurity);
+
+        return httpSecurity.build();
+    }
+
+//    private void configureExceptionHandling(HttpSecurity httpSecurity) throws Exception {
+//        httpSecurity
+//                .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
+//    }
+
+
+    private void configureCorsAndSecurity(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .headers(
+                        httpSecurityHeadersConfigurer ->
+                                httpSecurityHeadersConfigurer.frameOptions(
+                                        HeadersConfigurer.FrameOptionsConfig::disable
+                                )
+                )
+                // stateless한 rest api 이므로 csrf 공격 옵션 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // 로그인 폼 기본 설정(커스텀 x)
+                .formLogin(Customizer.withDefaults())
+                // 팝업 로그인 x
+                .httpBasic(HttpBasicConfigurer::disable)
+                // 프론트 혹은 다른 외부 api와의 통신 허용
+                .cors(Customizer.withDefaults())
+                // rest api를 위한 stateless 설정
+                .sessionManagement(configurer -> configurer
+                        .sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        )
+                );
+    }
+    private void configureAuth(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .authorizeHttpRequests(Customizer.withDefaults())
+                .authorizeHttpRequests(authorizeRequest -> {
+                    authorizeRequest
+                            .requestMatchers("/", "/.well-known/**", "/css/**",
+                                    "/*.ico", "/error", "/images/**").permitAll()
+                            .requestMatchers(permitAllRequest()).permitAll()        //비인증 api 허용 처리
+                            .requestMatchers(authRelatedEndpoints()).permitAll()
+                            .requestMatchers(additionalSwaggerRequests()).permitAll()
+                            .anyRequest().permitAll();      //지정하지 않은 url의 경우 인증 처리
+                });
+    }
+
+    private RequestMatcher[] permitAllRequest() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher(HttpMethod.GET, "/")     //list of 에 permit url 추가
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private RequestMatcher[] authRelatedEndpoints() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher("/api/tokens/**")
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private RequestMatcher[] additionalSwaggerRequests() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher("/swagger-ui/**"),
+                antMatcher("/swagger-ui"),
+                antMatcher("/swagger-ui.html"),
+                antMatcher("/swagger/**"),
+                antMatcher("/swagger-resources/**"),
+                antMatcher("/v3/api-docs/**"),
+                antMatcher("/profile")
+
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private void configureOAuth2(HttpSecurity httpSecurity) throws Exception{
+        httpSecurity
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)))
+                        .successHandler(customOAuth2LoginSuccessHandler::onAuthenticationSuccess)
+                        .failureHandler(customOAuth2LoginFailureHandler::onAuthenticationFailure)
+                );
+    }
+
+    private void addFilter(HttpSecurity httpSecurity){
+        httpSecurity
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/security/dto/JwtToken.java
+++ b/src/main/java/com/ploggingbuddy/security/dto/JwtToken.java
@@ -1,0 +1,16 @@
+package com.ploggingbuddy.security.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/ploggingbuddy/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ploggingbuddy/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.ploggingbuddy.security.filter;
+
+import com.trim.security.service.TokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenService tokenService;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // HttpServletRequest에서 JWT 토큰 추출
+        HttpServletRequest httpServletRequest = ((HttpServletRequest) request);
+
+        String requestURI = httpServletRequest.getRequestURI();
+        String token = resolveToken(request);
+
+        if (token != null && tokenService.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
+            Authentication authentication = tokenService.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            request.setAttribute("username", authentication.getName());
+            log.info("set Authentication to security context for '{}', uri: '{}', Role '{}'",
+                    authentication.getName(), ((HttpServletRequest) request).getRequestURI(), authentication.getAuthorities());
+        } else {
+            String uri = ((HttpServletRequest) request).getRequestURI();
+            if (!uri.equals("/health")) {
+                log.info("no valid JWT token found, uri: {}", uri);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ploggingbuddy/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ploggingbuddy/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.ploggingbuddy.security.filter;
 
-import com.trim.security.service.TokenService;
+import com.ploggingbuddy.security.service.TokenService;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/ploggingbuddy/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/ploggingbuddy/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,33 @@
+package com.ploggingbuddy.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException authException) {
+            String errorCodeName = authException.getMessage();
+            response.setStatus(401);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(new ObjectMapper().writeValueAsString(response));
+        }
+    }
+}

--- a/src/main/java/com/ploggingbuddy/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.ploggingbuddy.security.service;
 
+import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/ploggingbuddy/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/CustomUserDetailsService.java
@@ -1,0 +1,18 @@
+package com.ploggingbuddy.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberAdaptor memberAdaptor;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberAdaptor.queryByUsername(username);
+    }
+}

--- a/src/main/java/com/ploggingbuddy/security/service/TokenService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/TokenService.java
@@ -1,0 +1,136 @@
+package com.ploggingbuddy.security.service;
+
+import com.ploggingbuddy.security.dto.JwtToken;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class TokenService{
+    private final Key key;      //security yml 파일 생성 후 app.jwt.secret에 값 넣어주기
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final MemberAdaptor memberAdaptor;
+    private final UserDetailsService userDetailsService;
+
+    private final static int ACCESS_TOKEN_EXPIRATION_TIME = 1800000;
+    private final static int REFRESH_TOKEN_EXPIRATION_TIME = 604800000;
+
+    public TokenServiceImpl(@Value("${app.jwt.secret}") String key,
+                            AuthenticationManagerBuilder authenticationManagerBuilder,
+                            MemberAdaptor memberAdaptor,
+                            UserDetailsService userDetailsService) {
+        byte[] keyBytes = Decoders.BASE64.decode(key);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.memberAdaptor = memberAdaptor;
+        this.userDetailsService = userDetailsService;
+    }
+
+
+    public JwtToken login(Long memberId) {//TODO 나중에 사용 x -> only use social
+        Member member = memberAdaptor.queryById(memberId);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member.getUsername(), "",
+                member.getAuthorities());
+        JwtToken jwtToken = generateToken(authentication);
+        return jwtToken;
+    }
+
+    public JwtToken generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRATION_TIME);   // 30분
+        log.info("date = {}", accessTokenExpiresIn);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {           //TODO use in filter and annotation
+        // Jwt 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities = Arrays
+                .stream(claims.get("auth").toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication return
+        // UserDetails: interface, User: UserDetails를 구현한 class
+//        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        UserDetails principal = userDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+            throw new IllegalStateException("Invalid JWT Token");
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+            throw new IllegalStateException("Expired JWT Token");
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+            throw new IllegalStateException("Unsupported JWT Token");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+            throw new IllegalArgumentException("JWT claims string is empty.");
+        }
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/security/service/TokenService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/TokenService.java
@@ -67,7 +67,7 @@ public class TokenService{
                 .build();
     }
 
-    public Authentication getAuthentication(String accessToken) {           //TODO use in filter and annotation
+    public Authentication getAuthentication(String accessToken) {
         // Jwt 토큰 복호화
         Claims claims = parseClaims(accessToken);
 

--- a/src/main/java/com/ploggingbuddy/security/service/TokenService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/TokenService.java
@@ -1,5 +1,7 @@
 package com.ploggingbuddy.security.service;
 
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.global.auth.domain.CustomOAuthUser;
 import com.ploggingbuddy.security.dto.JwtToken;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -27,30 +29,17 @@ import java.util.stream.Collectors;
 public class TokenService{
     private final Key key;      //security yml 파일 생성 후 app.jwt.secret에 값 넣어주기
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final MemberAdaptor memberAdaptor;
     private final UserDetailsService userDetailsService;
 
     private final static int ACCESS_TOKEN_EXPIRATION_TIME = 1800000;
-    private final static int REFRESH_TOKEN_EXPIRATION_TIME = 604800000;
 
-    public TokenServiceImpl(@Value("${app.jwt.secret}") String key,
+    public TokenService(@Value("${app.jwt.secret}") String key,
                             AuthenticationManagerBuilder authenticationManagerBuilder,
-                            MemberAdaptor memberAdaptor,
                             UserDetailsService userDetailsService) {
         byte[] keyBytes = Decoders.BASE64.decode(key);
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.authenticationManagerBuilder = authenticationManagerBuilder;
-        this.memberAdaptor = memberAdaptor;
         this.userDetailsService = userDetailsService;
-    }
-
-
-    public JwtToken login(Long memberId) {//TODO 나중에 사용 x -> only use social
-        Member member = memberAdaptor.queryById(memberId);
-        Authentication authentication = new UsernamePasswordAuthenticationToken(member.getUsername(), "",
-                member.getAuthorities());
-        JwtToken jwtToken = generateToken(authentication);
-        return jwtToken;
     }
 
     public JwtToken generateToken(Authentication authentication) {
@@ -93,8 +82,6 @@ public class TokenService{
                 .collect(Collectors.toList());
 
         // UserDetails 객체를 만들어서 Authentication return
-        // UserDetails: interface, User: UserDetails를 구현한 class
-//        UserDetails principal = new User(claims.getSubject(), "", authorities);
         UserDetails principal = userDetailsService.loadUserByUsername(claims.getSubject());
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }

--- a/src/main/java/com/ploggingbuddy/security/service/TokenService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/TokenService.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class TokenService{
-    private final Key key;      //security yml 파일 생성 후 app.jwt.secret에 값 넣어주기
+    private final Key key;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final UserDetailsService userDetailsService;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ploggingbuddy


### PR DESCRIPTION
## 🔥*PullRequest*

카카오 소셜 로그인을 구현했습니다.
원래 임시 닉네임을 부여 후 닉네임 재설정 시스템을 만드려 했으나
기획 단계에서 닉네임을 직접 가져오는 방식으로 결정된 것 같습니다

따라서 필수로 가져오는 내용은 이메일, 닉네임,
선택 사항은 프로필 사진입니다.

추가로 테스트 용도로 unlink api를 구현했습니다.
GET - /kakao/test/unlink/{member_id} 요청을 통해 해당 계정과 카카오 서버의 연결을 끊어 회원가입, 필수 항목 동의 절차를 다시 진행할 수 있습니다.

### 💻 작업 내용
- 소셜 로그인/회원가입
- 회원탈퇴(테스트용)

### 테스트

security 기본 제공 화면인 localhost:8080/login 에서 진행합니다.
![image](https://github.com/user-attachments/assets/c39b1afc-428c-46ce-9b85-d858f3b1f727)

![image](https://github.com/user-attachments/assets/59fb47d8-1ed7-46dd-936d-f5cf4b10e4bc)

회원가입을 진행하면 리디렉션 URI param에 JWT Accesstoken을 넣어 프론트로 response 합니다. 프론트는 이 쿼리파라미터 부분에서 jwt 토큰을 추출해야합니다.

![image](https://github.com/user-attachments/assets/3c51260e-94d1-4f09-9962-ea42cfc1a836)


![image](https://github.com/user-attachments/assets/a2c943d9-5494-4762-a55b-dfd8aaab2a3d)
DB에 정상적으로 저장됐습니다.

unlink api 실행 후 http://localhost:8080/oauth2/authorization/kakao 에서 로그인하면 같은 과정을 진행합니다.


### 📟 관련 이슈
- Resolved: #3 

