### PR TITLE
[Feat/6] 회원 정보 API 구현 및 Authentication Resolver 등록

### DIFF
--- a/src/main/java/com/ploggingbuddy/application/member/GetMyInfoUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/GetMyInfoUseCase.java
@@ -1,0 +1,23 @@
+package com.ploggingbuddy.application.member;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.service.MemberService;
+import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
+import com.ploggingbuddy.presentation.member.dto.response.MemberResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class GetMyInfoUseCase {
+
+    //todo 모임 정보 추가
+    public MemberResponse execute(Member member) {
+        return MemberResponse.from(member);
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/application/member/UpdateMemberAddressUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/UpdateMemberAddressUseCase.java
@@ -3,6 +3,7 @@ package com.ploggingbuddy.application.member;
 import com.ploggingbuddy.domain.member.entity.Member;
 import com.ploggingbuddy.domain.member.service.MemberService;
 import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import com.ploggingbuddy.global.vo.Address;
 import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +18,10 @@ public class UpdateMemberAddressUseCase {
     private final MemberService memberService;
 
     public void execute(Member member, MemberRequest.UpdateAddress request) {
-        memberService.updateAddress(member, request.getDetailAddress()
-                , request.getLatitude(), request.getLongitude());
+        Address address = new Address(
+                request.getDetailAddress(), request.getLatitude(), request.getLongitude()
+        );
+        memberService.updateAddress(member, address);
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/application/member/UpdateMemberAddressUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/UpdateMemberAddressUseCase.java
@@ -17,7 +17,8 @@ public class UpdateMemberAddressUseCase {
     private final MemberService memberService;
 
     public void execute(Member member, MemberRequest.UpdateAddress request) {
-        memberService.updateNickname(member, request.getAddress());
+        memberService.updateAddress(member, request.getDetailAddress()
+                , request.getLatitude(), request.getLongitude());
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/application/member/UpdateMemberAddressUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/UpdateMemberAddressUseCase.java
@@ -1,0 +1,23 @@
+package com.ploggingbuddy.application.member;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.service.MemberService;
+import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateMemberAddressUseCase {
+
+    private final MemberService memberService;
+
+    public void execute(Member member, MemberRequest.UpdateAddress request) {
+        memberService.updateNickname(member, request.getAddress());
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/application/member/UpdateMemberDescriptionUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/UpdateMemberDescriptionUseCase.java
@@ -1,0 +1,24 @@
+package com.ploggingbuddy.application.member;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.service.MemberService;
+import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateMemberDescriptionUseCase {
+
+    private final MemberService memberService;
+
+    public void execute(Member member, MemberRequest.UpdateDescription request) {
+        memberService.updateNickname(member, request.getDescription());
+    }
+
+
+}

--- a/src/main/java/com/ploggingbuddy/application/member/UpdateMemberDescriptionUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/UpdateMemberDescriptionUseCase.java
@@ -17,7 +17,7 @@ public class UpdateMemberDescriptionUseCase {
     private final MemberService memberService;
 
     public void execute(Member member, MemberRequest.UpdateDescription request) {
-        memberService.updateNickname(member, request.getDescription());
+        memberService.updateDescription(member, request.getDescription());
     }
 
 

--- a/src/main/java/com/ploggingbuddy/application/member/UpdateMemberNicknameUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/member/UpdateMemberNicknameUseCase.java
@@ -1,0 +1,23 @@
+package com.ploggingbuddy.application.member;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.service.MemberService;
+import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateMemberNicknameUseCase {
+
+    private final MemberService memberService;
+
+    public void execute(Member member, MemberRequest.UpdateNickname request) {
+        memberService.updateNickname(member, request.getNickname());
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -5,10 +5,7 @@ import com.ploggingbuddy.global.vo.Address;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,7 +25,7 @@ import java.util.Collections;
                 @Index(name = "idx_member_username", columnList = "username"),
         }
 )
-public class Member extends BaseTimeEntity implements UserDetails {
+public class Member extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,22 +45,13 @@ public class Member extends BaseTimeEntity implements UserDetails {
     private String description;
 
     @Embedded
-    private Address address;
+    @Builder.Default
+    private Address address = new Address();;
 
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority(this.role.getName()));
-    }
-
-    @Override
-    public String getPassword() {
-        return "";
-    }
 
     //business
     public void updateNickname(String nickname) {

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.ploggingbuddy.domain.member.entity;
 
 import com.ploggingbuddy.domain.auditing.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,11 +32,18 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true, nullable = false)
     private String username;
 
     private String nickname;
 
     private String email;
+
+    @Lob
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    private String address;
 
     private String profileImageUrl;
 
@@ -51,4 +59,18 @@ public class Member extends BaseTimeEntity implements UserDetails {
     public String getPassword() {
         return "";
     }
+
+    //business
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateAddress(String address) {
+        this.address = address;
+    }
+
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.ploggingbuddy.domain.member.entity;
 
 import com.ploggingbuddy.domain.auditing.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -35,6 +36,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @Column(unique = true, nullable = false)
     private String username;
 
+    @Column(nullable = false)
+    @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
 
     private String email;

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -46,7 +46,9 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
-    private String address;
+    private String detailAddress;
+    private double latitude;
+    private double longitude;
 
     private String profileImageUrl;
 
@@ -72,8 +74,10 @@ public class Member extends BaseTimeEntity implements UserDetails {
         this.description = description;
     }
 
-    public void updateAddress(String address) {
-        this.address = address;
+    public void updateAddress(String detailAddress, double latitude, double longitude) {
+        this.detailAddress = detailAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.ploggingbuddy.domain.member.entity;
 
 import com.ploggingbuddy.domain.auditing.entity.BaseTimeEntity;
+import com.ploggingbuddy.global.vo.Address;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -46,9 +47,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
-    private String detailAddress;
-    private double latitude;
-    private double longitude;
+    @Embedded
+    private Address address;
 
     private String profileImageUrl;
 
@@ -74,10 +74,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
         this.description = description;
     }
 
-    public void updateAddress(String detailAddress, double latitude, double longitude) {
-        this.detailAddress = detailAddress;
-        this.latitude = latitude;
-        this.longitude = longitude;
+    public void updateAddress(Address address) {
+        this.address = address;
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/service/MemberService.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.ploggingbuddy.domain.member.service;
 
 import com.ploggingbuddy.domain.member.entity.Member;
 import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import com.ploggingbuddy.global.vo.Address;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,8 +24,8 @@ public class MemberService {
         member.updateDescription(description);
     }
 
-    public void updateAddress(Member member, String detailAddress, Double latitude, Double longitude) {
-        member.updateAddress(detailAddress, latitude, longitude);
+    public void updateAddress(Member member, Address address) {
+        member.updateAddress(address);
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/service/MemberService.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/service/MemberService.java
@@ -23,8 +23,8 @@ public class MemberService {
         member.updateDescription(description);
     }
 
-    public void updateAddress(Member member, String address) {
-        member.updateAddress(address);
+    public void updateAddress(Member member, String detailAddress, Double latitude, Double longitude) {
+        member.updateAddress(detailAddress, latitude, longitude);
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/service/MemberService.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/service/MemberService.java
@@ -1,0 +1,30 @@
+package com.ploggingbuddy.domain.member.service;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public void updateNickname(Member member, String nickname) {
+        member.updateNickname(nickname);
+    }
+
+    public void updateDescription(Member member, String description) {
+        member.updateDescription(description);
+    }
+
+    public void updateAddress(Member member, String address) {
+        member.updateAddress(address);
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/global/config/webMvc/WebMvcConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/webMvc/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.ploggingbuddy.global.config.webMvc;
 
+import com.ploggingbuddy.security.resolver.CustomAuthenticationPrincipalArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -13,6 +14,13 @@ import java.util.List;
 public class WebMvcConfig implements WebMvcConfigurer {
     //todo 환경변수 파일로
     private static final String CORS_FRONT_PATH = "http://localhost:3000";
+    private final CustomAuthenticationPrincipalArgumentResolver customAuthenticationPrincipalArgumentResolver;
+
+    //resolver
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(customAuthenticationPrincipalArgumentResolver);
+    }
 
     //CORS setting
     @Override

--- a/src/main/java/com/ploggingbuddy/global/vo/Address.java
+++ b/src/main/java/com/ploggingbuddy/global/vo/Address.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
 public class Address {
     private String detailAddress;

--- a/src/main/java/com/ploggingbuddy/global/vo/Address.java
+++ b/src/main/java/com/ploggingbuddy/global/vo/Address.java
@@ -1,0 +1,18 @@
+package com.ploggingbuddy.global.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Address {
+    private String detailAddress;
+    private double latitude;
+    private double longitude;
+
+}

--- a/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.ploggingbuddy.presentation.member.controller;
 
+import com.ploggingbuddy.application.member.GetMyInfoUseCase;
 import com.ploggingbuddy.application.member.UpdateMemberAddressUseCase;
 import com.ploggingbuddy.application.member.UpdateMemberDescriptionUseCase;
 import com.ploggingbuddy.application.member.UpdateMemberNicknameUseCase;
@@ -21,12 +22,19 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final UpdateMemberNicknameUseCase updateMemberNicknameUseCase;
-     private final UpdateMemberDescriptionUseCase updateMemberDescriptionUseCase;
-     private final UpdateMemberAddressUseCase updateMemberAddressUseCase;
+    private final UpdateMemberDescriptionUseCase updateMemberDescriptionUseCase;
+    private final UpdateMemberAddressUseCase updateMemberAddressUseCase;
+    private final GetMyInfoUseCase getMyInfoUseCase;
 
     @GetMapping("/test")
     public ResponseEntity<?> testMember(@CurrentMember Member member) {
         return ResponseEntity.ok(member.getNickname() + "" + member.getEmail());
+    }
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<?> getMyInfo(@CurrentMember Member member) {
+        return ResponseEntity.ok(getMyInfoUseCase.execute(member));
     }
 
     @Operation(summary = "닉네임 수정", description = "회원 닉네임을 수정합니다.")
@@ -39,14 +47,14 @@ public class MemberController {
     @Operation(summary = "자기소개 수정", description = "회원 자기소개를 수정합니다.")
     @PostMapping("/description")
     public ResponseEntity<?> updateDescription(@CurrentMember Member member, @RequestBody MemberRequest.UpdateDescription request) {
-         updateMemberDescriptionUseCase.execute(member, request);
+        updateMemberDescriptionUseCase.execute(member, request);
         return ResponseEntity.ok("Description updated successfully.");
     }
 
     @Operation(summary = "주소 수정", description = "회원 주소를 수정합니다.")
     @PostMapping("/address")
     public ResponseEntity<?> updateAddress(@CurrentMember Member member, @RequestBody MemberRequest.UpdateAddress request) {
-         updateMemberAddressUseCase.execute(member, request);
+        updateMemberAddressUseCase.execute(member, request);
         return ResponseEntity.ok("Address updated successfully.");
     }
 

--- a/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
@@ -1,23 +1,53 @@
 package com.ploggingbuddy.presentation.member.controller;
 
+import com.ploggingbuddy.application.member.UpdateMemberAddressUseCase;
+import com.ploggingbuddy.application.member.UpdateMemberDescriptionUseCase;
+import com.ploggingbuddy.application.member.UpdateMemberNicknameUseCase;
 import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
 import com.ploggingbuddy.security.aop.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member")
+@Tag(name = "Member Api", description = "회원 API")
 public class MemberController {
+
+    private final UpdateMemberNicknameUseCase updateMemberNicknameUseCase;
+     private final UpdateMemberDescriptionUseCase updateMemberDescriptionUseCase;
+     private final UpdateMemberAddressUseCase updateMemberAddressUseCase;
 
     @GetMapping("/test")
     public ResponseEntity<?> testMember(@CurrentMember Member member) {
         return ResponseEntity.ok(member.getNickname() + "" + member.getEmail());
+    }
+
+    @Operation(summary = "닉네임 수정", description = "회원 닉네임을 수정합니다.")
+    @PostMapping("/nickname")
+    public ResponseEntity<?> updateNickname(@CurrentMember Member member, @RequestBody MemberRequest.UpdateNickname request) {
+        updateMemberNicknameUseCase.execute(member, request);
+        return ResponseEntity.ok("Nickname updated successfully.");
+    }
+
+    @Operation(summary = "자기소개 수정", description = "회원 자기소개를 수정합니다.")
+    @PostMapping("/description")
+    public ResponseEntity<?> updateDescription(@CurrentMember Member member, @RequestBody MemberRequest.UpdateDescription request) {
+         updateMemberDescriptionUseCase.execute(member, request);
+        return ResponseEntity.ok("Description updated successfully.");
+    }
+
+    @Operation(summary = "주소 수정", description = "회원 주소를 수정합니다.")
+    @PostMapping("/address")
+    public ResponseEntity<?> updateAddress(@CurrentMember Member member, @RequestBody MemberRequest.UpdateAddress request) {
+         updateMemberAddressUseCase.execute(member, request);
+        return ResponseEntity.ok("Address updated successfully.");
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
 import com.ploggingbuddy.security.aop.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +40,7 @@ public class MemberController {
 
     @Operation(summary = "닉네임 수정", description = "회원 닉네임을 수정합니다.")
     @PostMapping("/nickname")
-    public ResponseEntity<?> updateNickname(@CurrentMember Member member, @RequestBody MemberRequest.UpdateNickname request) {
+    public ResponseEntity<?> updateNickname(@CurrentMember Member member, @RequestBody @Valid MemberRequest.UpdateNickname request) {
         updateMemberNicknameUseCase.execute(member, request);
         return ResponseEntity.ok("Nickname updated successfully.");
     }

--- a/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.ploggingbuddy.presentation.member.controller;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.security.aop.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    @GetMapping("/test")
+    public ResponseEntity<?> testMember(@CurrentMember Member member) {
+        return ResponseEntity.ok(member.getNickname() + "" + member.getEmail());
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
@@ -1,0 +1,30 @@
+package com.ploggingbuddy.presentation.member.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MemberRequest {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateNickname {
+        private String nickname;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateDescription {
+        private String description;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateAddress {
+        private String address;
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
@@ -28,7 +28,9 @@ public class MemberRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateAddress {
-        private String address;
+        private double latitude;
+        private double longitude;
+        private String detailAddress;
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
@@ -28,9 +28,9 @@ public class MemberRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateAddress {
+        private String detailAddress;
         private double latitude;
         private double longitude;
-        private String detailAddress;
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/dto/request/MemberRequest.java
@@ -1,12 +1,14 @@
 package com.ploggingbuddy.presentation.member.dto.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 public class MemberRequest {
 
     @Data
+    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateNickname {
@@ -14,6 +16,7 @@ public class MemberRequest {
     }
 
     @Data
+    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateDescription {
@@ -21,6 +24,7 @@ public class MemberRequest {
     }
 
     @Data
+    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateAddress {

--- a/src/main/java/com/ploggingbuddy/presentation/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/dto/response/MemberResponse.java
@@ -1,0 +1,31 @@
+package com.ploggingbuddy.presentation.member.dto.response;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberResponse {
+
+    private String nickname;
+    private String description;
+    private String address;
+    private String profileImageUrl;
+    // 작성한 모임
+    // 참석 예정인 모임
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .nickname(member.getNickname())
+                .description(member.getDescription())
+                .address(member.getAddress())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/presentation/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/dto/response/MemberResponse.java
@@ -14,7 +14,7 @@ public class MemberResponse {
 
     private String nickname;
     private String description;
-    private String address;
+    private String detailAddress;
     private String profileImageUrl;
     // 작성한 모임
     // 참석 예정인 모임
@@ -23,7 +23,7 @@ public class MemberResponse {
         return MemberResponse.builder()
                 .nickname(member.getNickname())
                 .description(member.getDescription())
-                .address(member.getAddress())
+                .detailAddress(member.getAddress().getDetailAddress())
                 .profileImageUrl(member.getProfileImageUrl())
                 .build();
     }

--- a/src/main/java/com/ploggingbuddy/security/aop/CurrentMember.java
+++ b/src/main/java/com/ploggingbuddy/security/aop/CurrentMember.java
@@ -3,9 +3,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.lang.annotation.*;
 
-@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@AuthenticationPrincipal
 public @interface CurrentMember {
 }

--- a/src/main/java/com/ploggingbuddy/security/resolver/CustomAuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/com/ploggingbuddy/security/resolver/CustomAuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,65 @@
+package com.ploggingbuddy.security.resolver;
+
+import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.security.aop.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.lang.annotation.Annotation;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public final class CustomAuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberAdaptor memberAdaptor;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return findMethodAnnotation(CurrentMember.class, parameter) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Object principal = authentication.getPrincipal();
+        CurrentMember annotation = findMethodAnnotation(CurrentMember.class, parameter);
+        if (principal == "anonymousUser") {
+            throw new RuntimeException();
+        }
+        findMethodAnnotation(CurrentMember.class, parameter);
+        Member member = memberAdaptor.queryByUsername(authentication.getName());
+
+        return member;
+    }
+
+    private <T extends Annotation> T findMethodAnnotation(Class<T> annotationClass, MethodParameter parameter) {
+        T annotation = parameter.getParameterAnnotation(annotationClass);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        Annotation[] annotations = parameter.getParameterAnnotations();
+        for (Annotation a : annotations) {
+            if (a.annotationType().isAnnotationPresent(annotationClass)) {
+                return parameter.getParameterAnnotation(annotationClass);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ploggingbuddy/security/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.ploggingbuddy.security.service;
 
 import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
+import com.ploggingbuddy.security.vo.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -14,6 +15,6 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberAdaptor.queryByUsername(username);
+        return new CustomUserDetails(memberAdaptor.queryByUsername(username));
     }
 }

--- a/src/main/java/com/ploggingbuddy/security/vo/CustomUserDetails.java
+++ b/src/main/java/com/ploggingbuddy/security/vo/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.ploggingbuddy.security.vo;
+
+import com.ploggingbuddy.domain.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> member.getRole().getName());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+}

--- a/src/test/java/com/ploggingbuddy/usecase/member/MemberUseCaseTest.java
+++ b/src/test/java/com/ploggingbuddy/usecase/member/MemberUseCaseTest.java
@@ -6,6 +6,7 @@ import com.ploggingbuddy.application.member.UpdateMemberDescriptionUseCase;
 import com.ploggingbuddy.application.member.UpdateMemberNicknameUseCase;
 import com.ploggingbuddy.domain.member.entity.Member;
 import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import com.ploggingbuddy.global.vo.Address;
 import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
 import com.ploggingbuddy.presentation.member.dto.response.MemberResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -46,11 +47,14 @@ public class MemberUseCaseTest {
     }
 
     private Member createTestMember() {
+        Address address = new Address(
+                "testDetailAddress", 1.0, 1.0
+        );
         return Member.builder()
                 .username("testUser")
                 .nickname("testNickname")
                 .description("testDescription")
-                .address("testAddress")
+                .address(address)
                 .email("testEmail")
                 .profileImageUrl("testProfileImageUrl")
                 .build();
@@ -64,16 +68,31 @@ public class MemberUseCaseTest {
                 .nickname("newNickname")
                 .build();
 
-        MemberRequest.UpdateNickname illegalRequest = MemberRequest.UpdateNickname.builder()
-                .nickname("")
-                .build();
-
         //when
         updateMemberNicknameUseCase.execute(member, request);
 
         //then
         assertEquals("newNickname", member.getNickname());
 
+    }
+
+    @Test
+    @DisplayName("update member address")
+    public void updateMemberAddressUseCaseTest() {
+        //given
+        MemberRequest.UpdateAddress request = MemberRequest.UpdateAddress.builder()
+                .detailAddress(
+                        "newDetailAddress"
+                )
+                .latitude(2.0)
+                .latitude(2.0)
+                .build();
+
+        //when
+        updateMemberAddressUseCase.execute(member, request);
+
+        //then
+        assertEquals(2.0, member.getAddress().getLatitude());
     }
 
     @Test

--- a/src/test/java/com/ploggingbuddy/usecase/member/MemberUseCaseTest.java
+++ b/src/test/java/com/ploggingbuddy/usecase/member/MemberUseCaseTest.java
@@ -1,0 +1,91 @@
+package com.ploggingbuddy.usecase.member;
+
+import com.ploggingbuddy.application.member.GetMyInfoUseCase;
+import com.ploggingbuddy.application.member.UpdateMemberAddressUseCase;
+import com.ploggingbuddy.application.member.UpdateMemberDescriptionUseCase;
+import com.ploggingbuddy.application.member.UpdateMemberNicknameUseCase;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import com.ploggingbuddy.presentation.member.dto.request.MemberRequest;
+import com.ploggingbuddy.presentation.member.dto.response.MemberResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Slf4j
+@SpringBootTest
+public class MemberUseCaseTest {
+
+    @Autowired
+    private UpdateMemberNicknameUseCase updateMemberNicknameUseCase;
+
+    @Autowired
+    private UpdateMemberDescriptionUseCase updateMemberDescriptionUseCase;
+
+    @Autowired
+    private UpdateMemberAddressUseCase updateMemberAddressUseCase;
+
+    @Autowired
+    private GetMyInfoUseCase myInfoUseCase;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        member = createTestMember();
+        memberRepository.save(member);
+    }
+
+    private Member createTestMember() {
+        return Member.builder()
+                .username("testUser")
+                .nickname("testNickname")
+                .description("testDescription")
+                .address("testAddress")
+                .email("testEmail")
+                .profileImageUrl("testProfileImageUrl")
+                .build();
+    }
+
+    @Test
+    @DisplayName("Update Member Nickname")
+    public void updateMemberNicknameUseCaseTest() {
+        //given
+        MemberRequest.UpdateNickname request = MemberRequest.UpdateNickname.builder()
+                .nickname("newNickname")
+                .build();
+
+        MemberRequest.UpdateNickname illegalRequest = MemberRequest.UpdateNickname.builder()
+                .nickname("")
+                .build();
+
+        //when
+        updateMemberNicknameUseCase.execute(member, request);
+
+        //then
+        assertEquals("newNickname", member.getNickname());
+
+    }
+
+    @Test
+    @DisplayName("get MyInfo test")
+    public void getMyInfoUseCaseTest() {
+        //given
+
+        //when
+        MemberResponse response = myInfoUseCase.execute(member);
+
+        //then
+        assertEquals("testNickname", response.getNickname());
+    }
+
+}


### PR DESCRIPTION
## 🔥*PullRequest*

### 💻 작업 내용
회원 정보 
등록 및 수정 - 주소, 자기소개, 닉네임
조회 - 닉네임, 자기소개, 프로필 이미지, 상세 주소 (모임 관련은 나중에 구현하겠습니다)

주소는 Embeded 객체로 생성해서 모임 도메인에도 사용할 수 있습니다.

그리고 기존 CurrentMember 어노테이션이 영속성 문제가 있어서
Resolver를 등록하고 member랑 인증객체(UserDetails)를 분리해서 해결했습니다.

이번 PR이 병합되고 나서 작업하시는걸 추천드립니다.

### 📟 관련 이슈
- Resolved: #6 

### 테스트
테스트 문제 없습니다.

