### PR TITLE
[Feat/11] 알림 서비스 test api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     //webclient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    //websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/ploggingbuddy/application/enrollment/GetEnrolledMemberListUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/enrollment/GetEnrolledMemberListUseCase.java
@@ -1,0 +1,22 @@
+package com.ploggingbuddy.application.enrollment;
+
+import com.ploggingbuddy.application.validator.GatheringValidator;
+import com.ploggingbuddy.domain.enrollment.service.EnrollmentService;
+import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import com.ploggingbuddy.presentation.enrollment.dto.response.GetEnrollmentListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class GetEnrolledMemberListUseCase {
+    private final EnrollmentService enrollmentService;
+    private final GatheringValidator gatheringValidator;
+
+    public GetEnrollmentListResponse execute(Long postId, Long memberId) {
+        gatheringValidator.validateGatheringPostIdExist(postId);
+        gatheringValidator.validateWriteUser(memberId, postId);
+        return new GetEnrollmentListResponse(enrollmentService.getEnrollmentList(postId));
+    }
+}

--- a/src/main/java/com/ploggingbuddy/application/enrollment/PostEnrollmentUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/enrollment/PostEnrollmentUseCase.java
@@ -1,0 +1,21 @@
+package com.ploggingbuddy.application.enrollment;
+
+import com.ploggingbuddy.application.validator.GatheringValidator;
+import com.ploggingbuddy.domain.enrollment.service.EnrollmentService;
+import com.ploggingbuddy.global.annotation.usecase.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class PostEnrollmentUseCase {
+    private final EnrollmentService enrollmentService;
+    private final GatheringValidator gatheringValidator;
+
+    public void execute(Long postId, Long userId) {
+        gatheringValidator.validateGatheringPostIdExist(postId);
+        gatheringValidator.validateEnrollableByPostId(postId);
+        enrollmentService.saveEnrollment(postId, userId);
+    }
+}

--- a/src/main/java/com/ploggingbuddy/application/validator/GatheringValidator.java
+++ b/src/main/java/com/ploggingbuddy/application/validator/GatheringValidator.java
@@ -4,6 +4,7 @@ import com.ploggingbuddy.domain.gathering.entity.Gathering;
 import com.ploggingbuddy.domain.gathering.entity.GatheringStatus;
 import com.ploggingbuddy.domain.gathering.repository.GatheringRepository;
 import com.ploggingbuddy.global.exception.base.BadRequestException;
+import com.ploggingbuddy.global.exception.base.ForbiddenException;
 import com.ploggingbuddy.global.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,19 +16,26 @@ public class GatheringValidator {
 
     public void validateWriteUser(Long requestUserId, Gathering gathering) {
         if (!gathering.getLeadUserId().equals(requestUserId)) {
-            throw new BadRequestException(ErrorCode.FORBIDDEN_EDIT_POST);
+            throw new ForbiddenException(ErrorCode.FORBIDDEN_EDIT_POST);
         }
     }
 
-    public void validateGatheringPostIdExist(Long gatheringPostId){
-        if(!gatheringRepository.existsById(gatheringPostId)){
+    public void validateWriteUser(Long requestUserId, Long postId) {
+        validateGatheringPostIdExist(postId);
+        if (!gatheringRepository.findById(postId).get().getLeadUserId().equals(requestUserId)) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN_EDIT_POST);
+        }
+    }
+
+    public void validateGatheringPostIdExist(Long gatheringPostId) {
+        if (!gatheringRepository.existsById(gatheringPostId)) {
             throw new BadRequestException(ErrorCode.INVALID_POST_ID);
         }
     }
 
     public void validateEnrollableByPostId(Long gatheringPostId) {
-        if(!gatheringRepository.findById(gatheringPostId)
-                .get().getPostStatus().equals(GatheringStatus.GATHERING)){
+        if (!gatheringRepository.findById(gatheringPostId)
+                .get().getPostStatus().equals(GatheringStatus.GATHERING)) {
             throw new BadRequestException(ErrorCode.POST_NOT_GATHERING_NOW);
         }
     }

--- a/src/main/java/com/ploggingbuddy/application/validator/GatheringValidator.java
+++ b/src/main/java/com/ploggingbuddy/application/validator/GatheringValidator.java
@@ -1,0 +1,34 @@
+package com.ploggingbuddy.application.validator;
+
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.gathering.entity.GatheringStatus;
+import com.ploggingbuddy.domain.gathering.repository.GatheringRepository;
+import com.ploggingbuddy.global.exception.base.BadRequestException;
+import com.ploggingbuddy.global.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GatheringValidator {
+    private final GatheringRepository gatheringRepository;
+
+    public void validateWriteUser(Long requestUserId, Gathering gathering) {
+        if (!gathering.getLeadUserId().equals(requestUserId)) {
+            throw new BadRequestException(ErrorCode.FORBIDDEN_EDIT_POST);
+        }
+    }
+
+    public void validateGatheringPostIdExist(Long gatheringPostId){
+        if(!gatheringRepository.existsById(gatheringPostId)){
+            throw new BadRequestException(ErrorCode.INVALID_POST_ID);
+        }
+    }
+
+    public void validateEnrollableByPostId(Long gatheringPostId) {
+        if(!gatheringRepository.findById(gatheringPostId)
+                .get().getPostStatus().equals(GatheringStatus.GATHERING)){
+            throw new BadRequestException(ErrorCode.POST_NOT_GATHERING_NOW);
+        }
+    }
+}

--- a/src/main/java/com/ploggingbuddy/domain/auditing/entity/BaseTimeEntity.java
+++ b/src/main/java/com/ploggingbuddy/domain/auditing/entity/BaseTimeEntity.java
@@ -23,8 +23,8 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdDate;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime lastModifiedDate;
+    private LocalDateTime lastModifiedAt;
 }

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/adaptor/EnrollmentAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/adaptor/EnrollmentAdaptor.java
@@ -1,0 +1,24 @@
+package com.ploggingbuddy.domain.enrollment.adaptor;
+
+import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
+import com.ploggingbuddy.domain.enrollment.repository.EnrollmentRepository;
+import com.ploggingbuddy.global.annotation.adaptor.Adaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Adaptor
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EnrollmentAdaptor {
+
+    private final EnrollmentRepository repository;
+
+    public List<Enrollment> queryByGatheringId(Long gatheringId) {
+        return repository.findAllByPostId(gatheringId);
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/entity/Enrollment.java
@@ -1,0 +1,36 @@
+package com.ploggingbuddy.domain.enrollment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Enrollment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Long postId;
+
+    private LocalDateTime enrollmentTime;
+
+    public Enrollment(Long memberId, Long postId) {
+        this.memberId = memberId;
+        this.postId = postId;
+        this.enrollmentTime = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/repository/EnrollmentRepository.java
@@ -3,6 +3,9 @@ package com.ploggingbuddy.domain.enrollment.repository;
 import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
+    List<Enrollment> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,8 @@
+package com.ploggingbuddy.domain.enrollment.repository;
+
+import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/service/EnrollmentService.java
@@ -1,20 +1,38 @@
 package com.ploggingbuddy.domain.enrollment.service;
 
-import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
 import com.ploggingbuddy.domain.enrollment.repository.EnrollmentRepository;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.member.repository.MemberRepository;
+import com.ploggingbuddy.global.exception.base.InternalServerErrorException;
+import com.ploggingbuddy.global.exception.code.ErrorCode;
+import com.ploggingbuddy.presentation.enrollment.dto.Enrollment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class EnrollmentService {
     private final EnrollmentRepository enrollmentRepository;
+    private final MemberRepository memberRepository;
 
     public void saveEnrollment(Long postId, Long userId) {
-        Enrollment enrollment = new Enrollment(postId, userId);
+        com.ploggingbuddy.domain.enrollment.entity.Enrollment enrollment = new com.ploggingbuddy.domain.enrollment.entity.Enrollment(postId, userId);
         enrollmentRepository.save(enrollment);
+    }
+
+    public List<Enrollment> getEnrollmentList(Long postId) {
+        return enrollmentRepository.findAllByPostId(postId)
+                .stream()
+                .map(enrollment -> {
+                    Member member = memberRepository.findById(enrollment.getMemberId())
+                            .orElseThrow(() -> new InternalServerErrorException(ErrorCode.INTERNAL_SERVER_ERROR));
+                    return new Enrollment(member.getId(), member.getNickname(), member.getProfileImageUrl());
+                })
+                .toList();
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/service/EnrollmentService.java
@@ -1,0 +1,20 @@
+package com.ploggingbuddy.domain.enrollment.service;
+
+import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
+import com.ploggingbuddy.domain.enrollment.repository.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EnrollmentService {
+    private final EnrollmentRepository enrollmentRepository;
+
+    public void saveEnrollment(Long postId, Long userId) {
+        Enrollment enrollment = new Enrollment(postId, userId);
+        enrollmentRepository.save(enrollment);
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/ploggingbuddy/domain/enrollment/service/EnrollmentService.java
@@ -5,7 +5,7 @@ import com.ploggingbuddy.domain.member.entity.Member;
 import com.ploggingbuddy.domain.member.repository.MemberRepository;
 import com.ploggingbuddy.global.exception.base.InternalServerErrorException;
 import com.ploggingbuddy.global.exception.code.ErrorCode;
-import com.ploggingbuddy.presentation.enrollment.dto.Enrollment;
+import com.ploggingbuddy.presentation.enrollment.dto.EnrollmentData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,13 +24,13 @@ public class EnrollmentService {
         enrollmentRepository.save(enrollment);
     }
 
-    public List<Enrollment> getEnrollmentList(Long postId) {
+    public List<EnrollmentData> getEnrollmentList(Long postId) {
         return enrollmentRepository.findAllByPostId(postId)
                 .stream()
                 .map(enrollment -> {
                     Member member = memberRepository.findById(enrollment.getMemberId())
                             .orElseThrow(() -> new InternalServerErrorException(ErrorCode.INTERNAL_SERVER_ERROR));
-                    return new Enrollment(member.getId(), member.getNickname(), member.getProfileImageUrl());
+                    return new EnrollmentData(member.getId(), member.getNickname(), member.getProfileImageUrl());
                 })
                 .toList();
     }

--- a/src/main/java/com/ploggingbuddy/domain/gathering/adaptor/GatheringAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/adaptor/GatheringAdaptor.java
@@ -1,0 +1,19 @@
+package com.ploggingbuddy.domain.gathering.adaptor;
+
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.global.annotation.adaptor.Adaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Adaptor
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GatheringAdaptor {
+
+    private final GatheringAdaptor gatheringAdaptor;
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/gathering/adaptor/GatheringAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/adaptor/GatheringAdaptor.java
@@ -1,6 +1,7 @@
 package com.ploggingbuddy.domain.gathering.adaptor;
 
 import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.gathering.repository.GatheringRepository;
 import com.ploggingbuddy.global.annotation.adaptor.Adaptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GatheringAdaptor {
 
-    private final GatheringAdaptor gatheringAdaptor;
+    private final GatheringRepository gatheringRepository;
+
+    public Gathering queryById(Long id) {
+        return gatheringRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("id를 찾을 수 없음: " + id));
+    }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/gathering/entity/GatheringStatus.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/entity/GatheringStatus.java
@@ -1,5 +1,5 @@
 package com.ploggingbuddy.domain.gathering.entity;
 
 public enum GatheringStatus {
-    RECRUITING, RECRUITING_FINISHED, DELETED, FINISHED
+    GATHERING, GATHERING_FINISHED, DELETED, FINISHED
 }

--- a/src/main/java/com/ploggingbuddy/domain/gathering/repository/GatheringRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/repository/GatheringRepository.java
@@ -16,4 +16,5 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT g FROM Gathering g WHERE g.id = :id")
     Optional<Gathering> findWithLockById(@Param("id") Long id);
+
 }

--- a/src/main/java/com/ploggingbuddy/domain/gathering/repository/GatheringRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/repository/GatheringRepository.java
@@ -1,10 +1,19 @@
 package com.ploggingbuddy.domain.gathering.repository;
 
 import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Gathering g WHERE g.id = :id")
+    Optional<Gathering> findWithLockById(@Param("id") Long id);
 }

--- a/src/main/java/com/ploggingbuddy/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/service/GatheringService.java
@@ -3,6 +3,7 @@ package com.ploggingbuddy.domain.gathering.service;
 import com.ploggingbuddy.domain.gathering.entity.Gathering;
 import com.ploggingbuddy.domain.gathering.entity.GatheringStatus;
 import com.ploggingbuddy.domain.gathering.repository.GatheringRepository;
+import com.ploggingbuddy.application.validator.GatheringValidator;
 import com.ploggingbuddy.global.exception.base.BadRequestException;
 import com.ploggingbuddy.global.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GatheringService {
     private final GatheringRepository gatheringRepository;
+    private final GatheringValidator gatheringValidator;
 
     // 신규 생성
     public void save(Gathering gathering) {
@@ -24,7 +26,7 @@ public class GatheringService {
     public void updatePostStatus(Long postId, GatheringStatus postStatus, Long requestUserId) {
         Gathering gathering = getGatheringPost(postId);
 
-        validateWriteUser(requestUserId, gathering);
+        gatheringValidator.validateWriteUser(requestUserId, gathering);
         gathering.updatePostStatus(postStatus);
 
     }
@@ -32,8 +34,8 @@ public class GatheringService {
     // 인원 수정
     public void updatePostGatheringAmount(Long postId, Long participantMaxNumber, Long memberId) {
         Gathering gathering = getGatheringPost(postId);
-        validateWriteUser(memberId, gathering);
-        if(gathering.getParticipantMaxNumber() > participantMaxNumber) {
+        gatheringValidator.validateWriteUser(memberId, gathering);
+        if (gathering.getParticipantMaxNumber() > participantMaxNumber) {
             throw new BadRequestException(ErrorCode.INVALID_UPDATE_GATHERING_AMOUNT_SIZE);
         }
         gathering.updateParticipantMaxNumber(participantMaxNumber);
@@ -44,9 +46,4 @@ public class GatheringService {
                 .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_POST_ID));
     }
 
-    private void validateWriteUser(Long requestUserId, Gathering gathering) {
-        if (!gathering.getLeadUserId().equals(requestUserId)) {
-            throw new BadRequestException(ErrorCode.FORBIDDEN_EDIT_POST);
-        }
-    }
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/adaptor/MemberAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/adaptor/MemberAdaptor.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Adaptor
 @RequiredArgsConstructor
@@ -23,6 +25,10 @@ public class MemberAdaptor {
     public Member queryById(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("id를 찾을 수 없음: " + id));
+    }
+
+    public List<Member> queryAllByIds(List<Long> ids) {
+        return memberRepository.findAllByIdIn(ids);
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/entity/Member.java
@@ -4,15 +4,8 @@ import com.ploggingbuddy.domain.auditing.entity.BaseTimeEntity;
 import com.ploggingbuddy.global.vo.Address;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.Collections;
 
 @Getter
 @Entity

--- a/src/main/java/com/ploggingbuddy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/repository/MemberRepository.java
@@ -2,11 +2,16 @@ package com.ploggingbuddy.domain.member.repository;
 
 import com.ploggingbuddy.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUsername(String username);
 
+    @Query("select m from member m where m.id In :ids")
+    List<Member> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/ploggingbuddy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/member/repository/MemberRepository.java
@@ -12,6 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUsername(String username);
 
-    @Query("select m from member m where m.id In :ids")
+    @Query("select m from Member m where m.id In :ids")
     List<Member> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/ploggingbuddy/domain/notification/adaptor/NotificationAdaptor.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/adaptor/NotificationAdaptor.java
@@ -1,0 +1,30 @@
+package com.ploggingbuddy.domain.notification.adaptor;
+
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.notification.entity.Notification;
+import com.ploggingbuddy.domain.notification.repository.NotificationRepository;
+import com.ploggingbuddy.global.annotation.adaptor.Adaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Adaptor
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationAdaptor {
+
+    private final NotificationRepository repository;
+
+    public List<Notification> queryByMemberOrderByCreatedAtDesc(Member member) {
+        return repository.findByMemberOrderByCreatedAtDesc(member);
+    }
+
+    public  List<Notification> queryByGatheringOrderByCreatedAtDesc(Gathering gathering) {
+        return repository.findByGatheringOrderByCreatedAtDesc(gathering);
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/entity/Notification.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/entity/Notification.java
@@ -1,0 +1,41 @@
+package com.ploggingbuddy.domain.notification.entity;
+
+import com.ploggingbuddy.domain.auditing.entity.BaseTimeEntity;
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gathering_id")
+    private Gathering gathering;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/entity/Notification.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/entity/Notification.java
@@ -38,4 +38,14 @@ public class Notification extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean isRead;
 
+    public static Notification create(Member member, Gathering gathering, String message, NotificationType notificationType) {
+        return Notification.builder()
+                .member(member)
+                .gathering(gathering)
+                .message(message)
+                .notificationType(notificationType)
+                .isRead(false)
+                .build();
+    }
+
 }

--- a/src/main/java/com/ploggingbuddy/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/entity/NotificationType.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
     MEMBER_JOINED("모임에 참가했습니다."),
-    NEW_MEMBER_JOINED("새로운 참가자가 모임에 참가했습니다."),
     STATUS_CHANGED("모임에 참여되었습니다.");
 
     private final String defaultMessage;

--- a/src/main/java/com/ploggingbuddy/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/entity/NotificationType.java
@@ -1,0 +1,18 @@
+package com.ploggingbuddy.domain.notification.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+
+    MEMBER_JOINED("모임에 참가했습니다."),
+    NEW_MEMBER_JOINED("새로운 참가자가 모임에 참가했습니다."),
+    STATUS_CHANGED("모임에 참여되었습니다.");
+
+    private final String defaultMessage;
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.ploggingbuddy.domain.notification.repository;
+
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByMemberOrderByCreatedAtDesc(Member member);
+    List<Notification> findByGatheringOrderByCreatedAtDesc(Gathering gathering);
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/sender/NotificationSender.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/sender/NotificationSender.java
@@ -1,0 +1,7 @@
+package com.ploggingbuddy.domain.notification.sender;
+
+import com.ploggingbuddy.domain.notification.entity.Notification;
+
+public interface NotificationSender {
+    void sendNotification(Notification notification);
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/sender/WebSocketNotificationSender.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/sender/WebSocketNotificationSender.java
@@ -1,0 +1,30 @@
+package com.ploggingbuddy.domain.notification.sender;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ploggingbuddy.domain.notification.entity.Notification;
+import com.ploggingbuddy.presentation.notification.dto.response.NotificationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketNotificationSender implements NotificationSender{
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void sendNotification(Notification notification) {
+        try {
+            String destination = "/topic/notifications/" + notification.getMember().getId();
+            NotificationMessage message = NotificationMessage.from(notification);
+            messagingTemplate.convertAndSend(destination, message);
+            log.info("웹소켓 알림 전송 완료 - 수신자: {}, 알림 ID: {}", notification.getMember().getId(), notification.getId());
+        } catch (Exception e) {
+            log.error("웹소켓 알림 전송 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/service/NotificationService.java
@@ -1,0 +1,27 @@
+package com.ploggingbuddy.domain.notification.service;
+
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Async
+    public void notifyMemberJoined(Gathering gathering, Member member) {
+        log.info("{} 모임에 참가했습니다. 참가자: {}", gathering.getGatheringName(), member.getNickname());
+
+
+    }
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ploggingbuddy/domain/notification/service/NotificationService.java
@@ -1,13 +1,21 @@
 package com.ploggingbuddy.domain.notification.service;
 
+import com.ploggingbuddy.domain.enrollment.adaptor.EnrollmentAdaptor;
+import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
 import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
 import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.notification.entity.Notification;
+import com.ploggingbuddy.domain.notification.entity.NotificationType;
 import com.ploggingbuddy.domain.notification.repository.NotificationRepository;
+import com.ploggingbuddy.domain.notification.sender.NotificationSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -16,11 +24,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationSender notificationSender;
+    private final EnrollmentAdaptor enrollmentAdaptor;
+    private final MemberAdaptor memberAdaptor;
 
     @Async
-    public void notifyMemberJoined(Gathering gathering, Member member) {
-        log.info("{} 모임에 참가했습니다. 참가자: {}", gathering.getGatheringName(), member.getNickname());
+    public void notifyMemberJoined(Gathering gathering, Member newMember) {
+        log.info("{} 모임에 참가했습니다. 참가자: {}", gathering.getGatheringName(), newMember.getNickname());
 
+        List<Long> memberIds = enrollmentAdaptor.queryByGatheringId(gathering.getId())
+                .stream().map(Enrollment::getMemberId)
+                .toList();
+
+        List<Member> members = memberAdaptor.queryAllByIds(memberIds);
+        for (Member member : members) {
+            String message = newMember.getNickname() + "님이 '" + gathering.getGatheringName() + "' 모임에 참가했습니다.";
+            Notification notification = Notification.create(member, gathering, message, NotificationType.MEMBER_JOINED);
+            notificationRepository.save(notification);
+
+            //알림 전송
+            notificationSender.sendNotification(notification);
+
+        }
 
     }
 

--- a/src/main/java/com/ploggingbuddy/global/config/asycn/AsyncConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/asycn/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.ploggingbuddy.global.config.asycn;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/com/ploggingbuddy/global/config/webSocket/WebSocketConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/webSocket/WebSocketConfig.java
@@ -18,7 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("*")
-                .withSockJS();
+                .setAllowedOrigins("*");
+//                .withSockJS();
     }
 }

--- a/src/main/java/com/ploggingbuddy/global/config/webSocket/WebSocketConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/webSocket/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.ploggingbuddy.global.config.webSocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins("*")
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/ploggingbuddy/global/exception/base/ForbiddenException.java
+++ b/src/main/java/com/ploggingbuddy/global/exception/base/ForbiddenException.java
@@ -1,0 +1,11 @@
+package com.ploggingbuddy.global.exception.base;
+
+import com.ploggingbuddy.global.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ForbiddenException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/ploggingbuddy/global/exception/base/InternalServerErrorException.java
+++ b/src/main/java/com/ploggingbuddy/global/exception/base/InternalServerErrorException.java
@@ -1,0 +1,11 @@
+package com.ploggingbuddy.global.exception.base;
+
+import com.ploggingbuddy.global.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class InternalServerErrorException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/ploggingbuddy/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/ploggingbuddy/global/exception/code/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode implements PloggingBuddyErrorCode{
     // 400 BAD REQUEST
     INVALID_POST_ID(HttpStatus.BAD_REQUEST, 400, "모임 글 id가 올바르지 않습니다."),
     INVALID_UPDATE_GATHERING_AMOUNT_SIZE(HttpStatus.BAD_REQUEST, 400, "수정 후 모임 인원이 수정 전 모임 인원보다 작을 수 없습니다."),
-
+    POST_NOT_GATHERING_NOW(HttpStatus.BAD_REQUEST, 400, "현재 해당 모집글이 모집하고 있지 않습니다."),
     // 403 forbidden
     FORBIDDEN_EDIT_POST(HttpStatus.FORBIDDEN, 403, "모임 글 수정 권한이 없는 유저입니다.");
 

--- a/src/main/java/com/ploggingbuddy/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/ploggingbuddy/global/exception/code/ErrorCode.java
@@ -13,10 +13,15 @@ public enum ErrorCode implements PloggingBuddyErrorCode{
     // 400 BAD REQUEST
     INVALID_POST_ID(HttpStatus.BAD_REQUEST, 400, "모임 글 id가 올바르지 않습니다."),
     INVALID_UPDATE_GATHERING_AMOUNT_SIZE(HttpStatus.BAD_REQUEST, 400, "수정 후 모임 인원이 수정 전 모임 인원보다 작을 수 없습니다."),
-    POST_NOT_GATHERING_NOW(HttpStatus.BAD_REQUEST, 400, "현재 해당 모집글이 모집하고 있지 않습니다."),
-    // 403 forbidden
-    FORBIDDEN_EDIT_POST(HttpStatus.FORBIDDEN, 403, "모임 글 수정 권한이 없는 유저입니다.");
+    POST_NOT_GATHERING_NOW(HttpStatus.BAD_REQUEST, 400, "현재 해당 모임 글이 모집하고 있지 않습니다."),
+    EXCEED_PARTICIPANT_LIMIT(HttpStatus.BAD_REQUEST, 400, "신청가능한 인원이 초과하였습니다."),
+    DUPLICATED_ENROLLMENT(HttpStatus.BAD_REQUEST, 400, "이미 신청한 모임 글 입니다."),
 
+    // 403 forbidden
+    FORBIDDEN_EDIT_POST(HttpStatus.FORBIDDEN, 403, "모임 글 수정 권한이 없는 유저입니다."),
+
+    // 500 internal server error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다. 서버 관리자에게 연락해주세요");
 
     @JsonIgnore
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ploggingbuddy/presentation/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/enrollment/controller/EnrollmentController.java
@@ -1,20 +1,20 @@
 package com.ploggingbuddy.presentation.enrollment.controller;
 
+import com.ploggingbuddy.application.enrollment.GetEnrolledMemberListUseCase;
 import com.ploggingbuddy.application.enrollment.PostEnrollmentUseCase;
 import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.presentation.enrollment.dto.response.GetEnrollmentListResponse;
 import com.ploggingbuddy.security.aop.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/enroll")
 @RequiredArgsConstructor
 public class EnrollmentController {
     private final PostEnrollmentUseCase postEnrollmentUseCase;
+    private final GetEnrolledMemberListUseCase getEnrolledMemberListUseCase;
 
     @PostMapping("/{postId}")
     public ResponseEntity<Void> postEnrollment(
@@ -22,5 +22,13 @@ public class EnrollmentController {
             @PathVariable Long postId) {
         postEnrollmentUseCase.execute(postId, member.getId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/enrolled-list/{postId}")
+    public ResponseEntity<GetEnrollmentListResponse> getEnrolledMemberList(
+            @CurrentMember Member member,
+            @PathVariable Long postId
+    ){
+        return ResponseEntity.ok(getEnrolledMemberListUseCase.execute(postId, member.getId()));
     }
 }

--- a/src/main/java/com/ploggingbuddy/presentation/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,26 @@
+package com.ploggingbuddy.presentation.enrollment.controller;
+
+import com.ploggingbuddy.application.enrollment.PostEnrollmentUseCase;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.security.aop.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/enroll")
+@RequiredArgsConstructor
+public class EnrollmentController {
+    private final PostEnrollmentUseCase postEnrollmentUseCase;
+
+    @PostMapping("/{postId}")
+    public ResponseEntity<Void> postEnrollment(
+            @CurrentMember Member member,
+            @PathVariable Long postId) {
+        postEnrollmentUseCase.execute(postId, member.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/Enrollment.java
+++ b/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/Enrollment.java
@@ -1,0 +1,8 @@
+package com.ploggingbuddy.presentation.enrollment.dto;
+
+public record Enrollment(
+        Long enrolledMemberId,
+        String name,
+        String profilePictureUrl
+) {
+}

--- a/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/EnrollmentData.java
+++ b/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/EnrollmentData.java
@@ -1,6 +1,6 @@
 package com.ploggingbuddy.presentation.enrollment.dto;
 
-public record Enrollment(
+public record EnrollmentData(
         Long enrolledMemberId,
         String name,
         String profilePictureUrl

--- a/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/response/GetEnrollmentListResponse.java
+++ b/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/response/GetEnrollmentListResponse.java
@@ -1,10 +1,10 @@
 package com.ploggingbuddy.presentation.enrollment.dto.response;
 
-import com.ploggingbuddy.presentation.enrollment.dto.Enrollment;
+import com.ploggingbuddy.presentation.enrollment.dto.EnrollmentData;
 
 import java.util.List;
 
 public record GetEnrollmentListResponse(
-        List<Enrollment> enrollmentDataList
+        List<EnrollmentData> enrollmentDataDataList
 ) {
 }

--- a/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/response/GetEnrollmentListResponse.java
+++ b/src/main/java/com/ploggingbuddy/presentation/enrollment/dto/response/GetEnrollmentListResponse.java
@@ -1,0 +1,10 @@
+package com.ploggingbuddy.presentation.enrollment.dto.response;
+
+import com.ploggingbuddy.presentation.enrollment.dto.Enrollment;
+
+import java.util.List;
+
+public record GetEnrollmentListResponse(
+        List<Enrollment> enrollmentDataList
+) {
+}

--- a/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/member/controller/MemberController.java
@@ -27,6 +27,7 @@ public class MemberController {
     private final UpdateMemberAddressUseCase updateMemberAddressUseCase;
     private final GetMyInfoUseCase getMyInfoUseCase;
 
+    //test
     @GetMapping("/test")
     public ResponseEntity<?> testMember(@CurrentMember Member member) {
         return ResponseEntity.ok(member.getNickname() + "" + member.getEmail());

--- a/src/main/java/com/ploggingbuddy/presentation/notification/controller/NotificationController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/notification/controller/NotificationController.java
@@ -1,0 +1,21 @@
+package com.ploggingbuddy.presentation.notification.controller;
+
+import com.ploggingbuddy.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+//테스트 용도입니다
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+
+}

--- a/src/main/java/com/ploggingbuddy/presentation/notification/controller/NotificationController.java
+++ b/src/main/java/com/ploggingbuddy/presentation/notification/controller/NotificationController.java
@@ -1,10 +1,15 @@
 package com.ploggingbuddy.presentation.notification.controller;
 
+import com.ploggingbuddy.domain.gathering.adaptor.GatheringAdaptor;
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.entity.Member;
 import com.ploggingbuddy.domain.notification.service.NotificationService;
+import com.ploggingbuddy.security.aop.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final GatheringAdaptor gatheringAdaptor;
 
+    @GetMapping("/test/{postId}")
+    public ResponseEntity<?> testNotification(@CurrentMember Member member, @PathVariable("postId") Long postId) {
+        Gathering gathering = gatheringAdaptor.queryById(postId);
+        notificationService.notifyMemberJoined(gathering, member);
+        return ResponseEntity.ok("Test notification sent successfully.");
+    }
 
 }

--- a/src/main/java/com/ploggingbuddy/presentation/notification/dto/response/NotificationMessage.java
+++ b/src/main/java/com/ploggingbuddy/presentation/notification/dto/response/NotificationMessage.java
@@ -1,0 +1,34 @@
+package com.ploggingbuddy.presentation.notification.dto.response;
+
+import com.ploggingbuddy.domain.notification.entity.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationMessage {
+    private Long id;
+    private String message;
+    private String type;
+    private LocalDateTime createdAt;
+    private Long gatheringId;
+    private String gatheringName;
+
+    public static NotificationMessage from(Notification notification) {
+        return NotificationMessage.builder()
+                .id(notification.getId())
+                .message(notification.getMessage())
+                .type(notification.getNotificationType().name())
+                .createdAt(notification.getCreatedAt())
+                .gatheringId(notification.getGathering().getId())
+                .gatheringName(notification.getGathering().getGatheringName())
+                .build();
+    }
+
+}

--- a/src/test/java/com/ploggingbuddy/domain/notification/WebSocketNotificationTest.java
+++ b/src/test/java/com/ploggingbuddy/domain/notification/WebSocketNotificationTest.java
@@ -1,0 +1,222 @@
+package com.ploggingbuddy.domain.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ploggingbuddy.domain.enrollment.adaptor.EnrollmentAdaptor;
+import com.ploggingbuddy.domain.enrollment.entity.Enrollment;
+import com.ploggingbuddy.domain.gathering.entity.Gathering;
+import com.ploggingbuddy.domain.member.adaptor.MemberAdaptor;
+import com.ploggingbuddy.domain.member.entity.Member;
+import com.ploggingbuddy.domain.notification.entity.Notification;
+import com.ploggingbuddy.domain.notification.entity.NotificationType;
+import com.ploggingbuddy.domain.notification.repository.NotificationRepository;
+import com.ploggingbuddy.domain.notification.sender.NotificationSender;
+import com.ploggingbuddy.domain.notification.service.NotificationService;
+import com.ploggingbuddy.presentation.notification.dto.response.NotificationMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class WebSocketNotificationTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private EnrollmentAdaptor enrollmentAdaptor;
+
+    @Mock
+    private MemberAdaptor memberAdaptor;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private NotificationService notificationService;
+    private NotificationSender notificationSender;
+
+    @BeforeEach
+    public void setup() {
+        // NotificationSender를 목으로 생성하고 NotificationService에 주입
+        notificationSender = mock(NotificationSender.class);
+        notificationService = new NotificationService(
+                notificationRepository,
+                notificationSender,
+                enrollmentAdaptor,
+                memberAdaptor
+        );
+    }
+
+    @Test
+    @DisplayName("새 멤버가 모임에 가입하면 모임 멤버들에게 웹소켓 알림이 전송되어야 한다")
+    public void testNotifyMemberJoinedSendsWebSocketNotifications() {
+        // Given
+        Long gatheringId = 1L;
+        Long memberId1 = 1L;
+        Long memberId2 = 2L;
+        Long newMemberId = 3L;
+
+        // 테스트 데이터 생성
+        Gathering gathering = Gathering.builder()
+                .id(gatheringId)
+                .gatheringName("테스트 모임")
+                .build();
+
+        Member existingMember1 = Member.builder()
+                .id(memberId1)
+                .nickname("기존멤버1")
+                .build();
+
+        Member existingMember2 = Member.builder()
+                .id(memberId2)
+                .nickname("기존멤버2")
+                .build();
+
+        Member newMember = Member.builder()
+                .id(newMemberId)
+                .nickname("새멤버")
+                .build();
+
+        List<Enrollment> enrollments = Arrays.asList(
+                Enrollment.builder().memberId(memberId1).postId(gatheringId).build(),
+                Enrollment.builder().memberId(memberId2).postId(gatheringId).build()
+        );
+
+        List<Member> existingMembers = Arrays.asList(existingMember1, existingMember2);
+
+        // Mock 설정
+        when(enrollmentAdaptor.queryByGatheringId(gatheringId)).thenReturn(enrollments);
+        when(memberAdaptor.queryAllByIds(Arrays.asList(memberId1, memberId2))).thenReturn(existingMembers);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> {
+            Notification notification = invocation.getArgument(0);
+            return Notification.builder()
+                    .id(1L)
+                    .member(notification.getMember())
+                    .gathering(notification.getGathering())
+                    .message(notification.getMessage())
+                    .notificationType(notification.getNotificationType())
+                    .isRead(notification.isRead())
+                    .build();
+        });
+
+        // When
+        notificationService.notifyMemberJoined(gathering, newMember);
+
+        // Then
+        // 각 기존 멤버에 대해 알림이 저장되었는지 확인
+        verify(notificationRepository, times(2)).save(any(Notification.class));
+        
+        // NotificationSender가 호출되었는지 확인
+        verify(notificationSender, times(2)).sendNotification(any(Notification.class));
+        
+        // 전송된 알림 내용 검증
+        ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationSender, times(2)).sendNotification(notificationCaptor.capture());
+        
+        List<Notification> capturedNotifications = notificationCaptor.getAllValues();
+        for (Notification notification : capturedNotifications) {
+            assertThat(notification.getMessage()).contains(newMember.getNickname());
+            assertThat(notification.getMessage()).contains(gathering.getGatheringName());
+            assertThat(notification.getNotificationType()).isEqualTo(NotificationType.MEMBER_JOINED);
+            assertThat(notification.getGathering().getId()).isEqualTo(gatheringId);
+            assertThat(notification.getMember().getId()).isIn(memberId1, memberId2);
+        }
+    }
+
+    @Test
+    @DisplayName("WebSocketNotificationSender가 SimpMessagingTemplate을 통해 메시지를 전송하는지 확인")
+    public void testWebSocketNotificationSenderSendsMessage() {
+        // Given
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        // WebSocketNotificationSender 생성
+        NotificationSender webSocketSender = new WebSocketNotificationSenderTestImpl(messagingTemplate, objectMapper);
+        
+        Long gatheringId = 1L;
+        Long memberId = 1L;
+        
+        // 테스트 데이터 생성
+        Gathering gathering = Gathering.builder()
+                .id(gatheringId)
+                .gatheringName("테스트 모임")
+                .build();
+
+        Member member = Member.builder()
+                .id(memberId)
+                .nickname("테스트멤버")
+                .build();
+        
+        String message = "새멤버님이 '테스트 모임' 모임에 참가했습니다.";
+        Notification notification = Notification.create(member, gathering, message, NotificationType.MEMBER_JOINED);
+        // SuperBuilder를 통해 새 객체를 생성하여 id 설정
+        notification = Notification.builder()
+                .id(1L)
+                .member(notification.getMember())
+                .gathering(notification.getGathering())
+                .message(notification.getMessage())
+                .notificationType(notification.getNotificationType())
+                .isRead(notification.isRead())
+                .build();
+        
+        // 목 설정
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<NotificationMessage> messageCaptor = ArgumentCaptor.forClass(NotificationMessage.class);
+        
+        // When
+        webSocketSender.sendNotification(notification);
+        
+        // Then
+        // SimpMessagingTemplate이 호출되었는지 확인
+        verify(messagingTemplate).convertAndSend(destinationCaptor.capture(), messageCaptor.capture());
+        
+        // 목적지 확인
+        String destination = destinationCaptor.getValue();
+        assertThat(destination).isEqualTo("/topic/notifications/" + memberId);
+        
+        // 메시지 내용 확인
+        NotificationMessage capturedMessage = messageCaptor.getValue();
+        assertThat(capturedMessage.getId()).isEqualTo(notification.getId());
+        assertThat(capturedMessage.getMessage()).isEqualTo(message);
+        assertThat(capturedMessage.getType()).isEqualTo(NotificationType.MEMBER_JOINED.name());
+        assertThat(capturedMessage.getGatheringId()).isEqualTo(gatheringId);
+        assertThat(capturedMessage.getGatheringName()).isEqualTo(gathering.getGatheringName());
+    }
+    
+    /**
+     * 테스트용 WebSocketNotificationSender 구현체
+     */
+    private static class WebSocketNotificationSenderTestImpl implements NotificationSender {
+        private final SimpMessagingTemplate messagingTemplate;
+        private final ObjectMapper objectMapper;
+        
+        public WebSocketNotificationSenderTestImpl(SimpMessagingTemplate messagingTemplate, ObjectMapper objectMapper) {
+            this.messagingTemplate = messagingTemplate;
+            this.objectMapper = objectMapper;
+        }
+        
+        @Override
+        public void sendNotification(Notification notification) {
+            try {
+                String destination = "/topic/notifications/" + notification.getMember().getId();
+                NotificationMessage message = NotificationMessage.from(notification);
+                messagingTemplate.convertAndSend(destination, message);
+            } catch (Exception e) {
+                // 테스트에서는 예외 무시
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔥*PullRequest*

### 📟 관련 이슈
- Resolved: #11 


### 💻 작업 내용
테스트 용도로 알림 서비스를 웹소켓으로 구현했습니다.

연결 방식은 먼저 프론트에서 로그인 성공 시 jwt 토큰과 member id를 localStorage에 저장합니다.
이후 모든 페이지가 로드될 때, 프론트에서는 `ws://{백엔드 url}/ws` 로 연결하고,
`/topic/notifications/${memberId}` 로 알림을 구독 후 메시지를 지속적으로 수신하면 됩니다.

기존 코드를 수정하지 않았으므로 기능에는 지장이 없고, 만약에 시간 여유가 생긴다면 프론트와 협업해서 구현할 수 있을 것 같습니다.
