### PR TITLE
[Feat/#29] 기획 수정사항 반영 및 게시글 상태 스케줄링 구현

### DIFF
--- a/src/main/java/com/ploggingbuddy/application/gathering/CreateGatheringUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/gathering/CreateGatheringUseCase.java
@@ -4,6 +4,7 @@ import com.ploggingbuddy.application.validator.GatheringValidator;
 import com.ploggingbuddy.domain.gathering.entity.Gathering;
 import com.ploggingbuddy.domain.gathering.service.GatheringService;
 import com.ploggingbuddy.domain.postImage.service.PostImageService;
+import com.ploggingbuddy.domain.scheduler.service.ScheduledTaskService;
 import com.ploggingbuddy.global.annotation.usecase.UseCase;
 import com.ploggingbuddy.presentation.gathering.dto.request.PostGatheringPostDto;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateGatheringUseCase {
     private final GatheringService gatheringService;
     private final PostImageService postImageService;
+    private final ScheduledTaskService scheduledTaskService;
     private final GatheringValidator gatheringValidator;
 
+    @Transactional
     public void execute(PostGatheringPostDto postGatheringPostDto, Long userId) {
         gatheringValidator.validateGatheringEndTime(postGatheringPostDto.gatheringEndTime());
         Gathering gathering = new Gathering(userId,
@@ -28,10 +31,11 @@ public class CreateGatheringUseCase {
                 postGatheringPostDto.spotLongitude(),
                 postGatheringPostDto.gatheringEndTime(),
                 postGatheringPostDto.gatheringTime());
-        Long postId = gatheringService.save(gathering).getId();
+        gathering = gatheringService.save(gathering);
+        scheduledTaskService.addTask(gathering.getId(), gathering.getGatheringTime());
 
         if (postGatheringPostDto.imageList() != null && !postGatheringPostDto.imageList().isEmpty()) {
-            postImageService.saveAll(postGatheringPostDto.imageList(), postId);
+            postImageService.saveAll(postGatheringPostDto.imageList(), gathering.getId());
         }
     }
 }

--- a/src/main/java/com/ploggingbuddy/application/gathering/CreateGatheringUseCase.java
+++ b/src/main/java/com/ploggingbuddy/application/gathering/CreateGatheringUseCase.java
@@ -26,7 +26,8 @@ public class CreateGatheringUseCase {
                 postGatheringPostDto.spotName(),
                 postGatheringPostDto.spotLatitude(),
                 postGatheringPostDto.spotLongitude(),
-                postGatheringPostDto.gatheringEndTime());
+                postGatheringPostDto.gatheringEndTime(),
+                postGatheringPostDto.gatheringTime());
         Long postId = gatheringService.save(gathering).getId();
 
         if (postGatheringPostDto.imageList() != null && !postGatheringPostDto.imageList().isEmpty()) {

--- a/src/main/java/com/ploggingbuddy/domain/gathering/entity/Gathering.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/entity/Gathering.java
@@ -37,6 +37,8 @@ public class Gathering {
 
     private LocalDateTime gatheringEndTime;
 
+    private LocalDateTime gatheringTime;
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 
@@ -51,7 +53,7 @@ public class Gathering {
         this.participantMaxNumber = participantNumberMax;
     }
 
-    public Gathering(Long leadUserId, String gatheringName, String content, Long participantMaxNumber, String spotStringAddress, Double spotLatitude, Double spotLongitude, LocalDateTime gatheringEndTime) {
+    public Gathering(Long leadUserId, String gatheringName, String content, Long participantMaxNumber, String spotStringAddress, Double spotLatitude, Double spotLongitude, LocalDateTime gatheringEndTime, LocalDateTime gatheringTime) {
         this.leadUserId = leadUserId;
         this.gatheringName = gatheringName;
         this.content = content;
@@ -61,6 +63,7 @@ public class Gathering {
         this.spotLatitude = spotLatitude;
         this.spotLongitude = spotLongitude;
         this.gatheringEndTime = gatheringEndTime;
+        this.gatheringTime = gatheringTime;
     }
 
 }

--- a/src/main/java/com/ploggingbuddy/domain/gathering/repository/GatheringRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/repository/GatheringRepository.java
@@ -34,6 +34,12 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long> {
 
     List<Gathering> findByGatheringEndTimeLessThanEqualAndPostStatus(LocalDateTime now, GatheringStatus postStatus);
 
+    List<Gathering> findByGatheringTimeLessThanAndPostStatusNotIn(
+            LocalDateTime now,
+            List<GatheringStatus> excludedStatuses
+    );
+
+
     @Query("SELECT g FROM Gathering g WHERE g.spotLatitude BETWEEN :minLat AND :maxLat AND g.spotLongitude BETWEEN :minLon AND :maxLon")
     List<Gathering> findByLatitudeLongitudeInRange(
             @Param("minLat") Double minLat,

--- a/src/main/java/com/ploggingbuddy/domain/gathering/scheduler/GatheringStatusScheduler.java
+++ b/src/main/java/com/ploggingbuddy/domain/gathering/scheduler/GatheringStatusScheduler.java
@@ -25,6 +25,10 @@ public class GatheringStatusScheduler {
     public void updatePostStatus() {
         System.out.println("scheduler running..." + LocalDateTime.now());
 
+        // 모집 종료시각에 따른 모집 마감 자동 스케줄러
+        // 0명 신청시 모임불가(모집 실패) GATHERING_FAILED로 이동
+        // 1명 이상 신청시 모임개설유저의 모임 여부 결정을 기다리는 GATHERING_PENDING 값
+        // GATHERING_PENDING 상태에서 모임개설유저가 모임 강행으로 결정시 GATHERING_CONFIRMED 값
         List<Gathering> gatheringPostsToClose = gatheringRepository.findByGatheringEndTimeLessThanEqualAndPostStatus(LocalDateTime.now(), GatheringStatus.GATHERING);
         for (Gathering gathering : gatheringPostsToClose) {
             gatheredCnt = enrollmentService.getEnrolledCount(gathering.getId());
@@ -32,6 +36,19 @@ public class GatheringStatusScheduler {
                 gathering.updatePostStatus(GatheringStatus.GATHERING_FAILED);
             }else if(gatheredCnt>0){
                 gathering.updatePostStatus(GatheringStatus.GATHERING_PENDING);
+            }
+        }
+
+        // 모임시각이 지난 gathering 게시글 상태 자동 변동 스케줄러
+        // 성사되지 않은 모임(모집인원 0명(이 경우 자동스케줄러에서 진행됨)/ N명 신청했으나 모임개설유저가 모임 미진행 선택시/ 모임 개최 여부 대기 중 모임시각이 지날시), GATHERING_FAILED 값
+        // 성공적으로 성사된 모임(GATHERING_CONFIRMED)일때, FINISHED 값
+        List<GatheringStatus> excludeStatus = List.of(GatheringStatus.FINISHED, GatheringStatus.GATHERING_FAILED);
+        List<Gathering> gatheringPostToEnd = gatheringRepository.findByGatheringTimeLessThanAndPostStatusNotIn(LocalDateTime.now(), excludeStatus);
+        for (Gathering gathering : gatheringPostToEnd) {
+            if(gathering.getPostStatus().equals(GatheringStatus.GATHERING_PENDING)){
+                gathering.updatePostStatus(GatheringStatus.GATHERING_FAILED);
+            }else if(gathering.getPostStatus().equals(GatheringStatus.GATHERING_CONFIRMED)){
+                gathering.updatePostStatus(GatheringStatus.FINISHED);
             }
         }
     }

--- a/src/main/java/com/ploggingbuddy/domain/scheduler/entity/ScheduledStatus.java
+++ b/src/main/java/com/ploggingbuddy/domain/scheduler/entity/ScheduledStatus.java
@@ -1,0 +1,5 @@
+package com.ploggingbuddy.domain.scheduler.entity;
+
+public enum ScheduledStatus {
+    PENDING, COMPLETE
+}

--- a/src/main/java/com/ploggingbuddy/domain/scheduler/entity/ScheduledTask.java
+++ b/src/main/java/com/ploggingbuddy/domain/scheduler/entity/ScheduledTask.java
@@ -1,0 +1,40 @@
+package com.ploggingbuddy.domain.scheduler.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder
+public class ScheduledTask {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long gatheringId;
+
+    @NotNull
+    private LocalDateTime executeTime;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ScheduledStatus status;
+
+    public void scheduledMessageStatusUpdate() {
+        this.status = ScheduledStatus.COMPLETE;
+    }
+
+    public ScheduledTask(Long gatheringId, LocalDateTime executeTime, ScheduledStatus status) {
+        this.gatheringId = gatheringId;
+        this.executeTime = executeTime;
+        this.status = status;
+    }
+
+
+}

--- a/src/main/java/com/ploggingbuddy/domain/scheduler/repository/ScheduledTaskRepository.java
+++ b/src/main/java/com/ploggingbuddy/domain/scheduler/repository/ScheduledTaskRepository.java
@@ -1,0 +1,11 @@
+package com.ploggingbuddy.domain.scheduler.repository;
+
+import com.ploggingbuddy.domain.scheduler.entity.ScheduledStatus;
+import com.ploggingbuddy.domain.scheduler.entity.ScheduledTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScheduledTaskRepository extends JpaRepository<ScheduledTask, Long> {
+    List<ScheduledTask> findByStatus(ScheduledStatus status);
+}

--- a/src/main/java/com/ploggingbuddy/domain/scheduler/service/ScheduledTaskProcessor.java
+++ b/src/main/java/com/ploggingbuddy/domain/scheduler/service/ScheduledTaskProcessor.java
@@ -1,0 +1,29 @@
+package com.ploggingbuddy.domain.scheduler.service;
+
+import com.ploggingbuddy.domain.gathering.scheduler.GatheringStatusScheduler;
+import com.ploggingbuddy.domain.scheduler.entity.ScheduledTask;
+import com.ploggingbuddy.domain.scheduler.repository.ScheduledTaskRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledTaskProcessor {
+
+    private final ScheduledTaskRepository scheduledTaskRepository;
+    private final GatheringStatusScheduler gatheringStatusScheduler;
+
+    @Transactional
+    public void processInitScheduling(ScheduledTask task, Long delaySeconds) {
+        if (delaySeconds <= 0) {
+            gatheringStatusScheduler.updateGatheringStatusDone(task.getGatheringId());
+            task = scheduledTaskRepository.getById(task.getId());
+            task.scheduledMessageStatusUpdate();
+            scheduledTaskRepository.delete(task);
+        }
+    }
+}

--- a/src/main/java/com/ploggingbuddy/domain/scheduler/service/ScheduledTaskService.java
+++ b/src/main/java/com/ploggingbuddy/domain/scheduler/service/ScheduledTaskService.java
@@ -1,0 +1,82 @@
+package com.ploggingbuddy.domain.scheduler.service;
+
+import com.ploggingbuddy.domain.gathering.scheduler.GatheringStatusScheduler;
+import com.ploggingbuddy.domain.gathering.service.GatheringService;
+import com.ploggingbuddy.domain.scheduler.entity.ScheduledStatus;
+import com.ploggingbuddy.domain.scheduler.entity.ScheduledTask;
+import com.ploggingbuddy.domain.scheduler.repository.ScheduledTaskRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledTaskService {
+    @Qualifier("taskScheduler")
+    private final TaskScheduler taskScheduler;
+    private final ScheduledTaskRepository scheduledTaskRepository;
+    private final GatheringStatusScheduler gatheringStatusScheduler;
+
+    @Transactional
+    @EventListener(ApplicationReadyEvent.class)
+    public void initScheduledTask() {
+        List<ScheduledTask> scheduledTaskList =
+                scheduledTaskRepository.findByStatus(ScheduledStatus.PENDING);
+
+        scheduledTaskList.forEach(task -> {
+            Long delaySeconds = calculateDelaySeconds(LocalDateTime.now(), task.getExecuteTime());
+
+            if (delaySeconds <= 0) {
+                gatheringStatusScheduler.updateGatheringStatusDone(task.getGatheringId());
+                task.scheduledMessageStatusUpdate();
+                scheduledTaskRepository.delete(task);
+            } else {
+                Runnable updateStatus = updateStatusAsDone(task.getGatheringId());
+
+                ZoneId zone = ZoneId.systemDefault();
+                Instant instant = task.getExecuteTime().plusHours(1).atZone(zone).toInstant();
+
+                taskScheduler.schedule(updateStatus, instant);
+            }
+        });
+    }
+
+    @Transactional
+    public void addTask(Long postId, LocalDateTime gatheringTime) {
+        LocalDateTime doneScheduledTime = gatheringTime.plusHours(1);
+
+        ScheduledTask scheduledTask = new ScheduledTask(postId, doneScheduledTime, ScheduledStatus.PENDING);
+        scheduledTaskRepository.save(scheduledTask);
+
+        Runnable updateStatus = updateStatusAsDone(postId);
+
+        ZoneId zone = ZoneId.systemDefault();
+        Instant instant = doneScheduledTime.atZone(zone).toInstant();
+
+        taskScheduler.schedule(updateStatus, instant);
+
+    }
+
+    public Runnable updateStatusAsDone(Long postId) {
+        return () -> {
+            gatheringStatusScheduler.updateGatheringStatusDone(postId);
+        };
+    }
+
+    private long calculateDelaySeconds(LocalDateTime now, LocalDateTime targetDateTime) {
+        Duration duration = Duration.between(now, targetDateTime);
+        return duration.getSeconds();
+    }
+
+}
+

--- a/src/main/java/com/ploggingbuddy/global/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/ploggingbuddy/global/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.ploggingbuddy.global.config.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    private static final int POOL_SIZE = 3;
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler(){
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        scheduler.setThreadNamePrefix("My Scheduler - ");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/ploggingbuddy/presentation/gathering/dto/request/PostGatheringPostDto.java
+++ b/src/main/java/com/ploggingbuddy/presentation/gathering/dto/request/PostGatheringPostDto.java
@@ -11,6 +11,7 @@ public record PostGatheringPostDto(
         Double spotLongitude,
         Double spotLatitude,
         LocalDateTime gatheringEndTime,
+        LocalDateTime gatheringTime,
         List<String> imageList
 ) {
 }

--- a/src/main/java/com/ploggingbuddy/presentation/gathering/dto/response/GetGatheringDetailResponse.java
+++ b/src/main/java/com/ploggingbuddy/presentation/gathering/dto/response/GetGatheringDetailResponse.java
@@ -3,6 +3,7 @@ package com.ploggingbuddy.presentation.gathering.dto.response;
 import com.ploggingbuddy.domain.gathering.entity.Gathering;
 import com.ploggingbuddy.domain.gathering.entity.GatheringStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record GetGatheringDetailResponse(
@@ -15,6 +16,8 @@ public record GetGatheringDetailResponse(
         String address,
         Double longitude,
         Double latitude,
+        LocalDateTime gatheringEndTime,
+        LocalDateTime gatheringTime,
         String content,
         List<String> imageList
 ) {
@@ -28,6 +31,8 @@ public record GetGatheringDetailResponse(
                 gathering.getSpotStringAddress(),
                 gathering.getSpotLongitude(),
                 gathering.getSpotLatitude(),
+                gathering.getGatheringEndTime(),
+                gathering.getGatheringTime(),
                 gathering.getContent(),
                 imageList
         );

--- a/src/main/java/com/ploggingbuddy/presentation/gathering/dto/response/GetGatheringsNearSpotResponse.java
+++ b/src/main/java/com/ploggingbuddy/presentation/gathering/dto/response/GetGatheringsNearSpotResponse.java
@@ -1,0 +1,10 @@
+package com.ploggingbuddy.presentation.gathering.dto.response;
+
+import com.ploggingbuddy.presentation.gathering.dto.GatheringPreview;
+
+import java.util.List;
+
+public record GetGatheringsNearSpotResponse(
+    List<GatheringPreview> gatheringPreviewList
+) {
+}


### PR DESCRIPTION
## 🔥*PullRequest*

### 📟 관련 이슈
- Resolved: #29 

### 💻 작업 내용
- 기획 수정사항 - 모임 날짜 필드 추가 반영
- dto, api 로직 수정
- 모임 날짜 기준 게시글 상태 스케줄링 구현
- ApplicationReadyEvent 이벤트 리스너를 사용해 스케줄링 로직 구현 완료

### 테스트
수정 api 테스트 완료
스케줄링 기능 테스트 완료
